### PR TITLE
store: ditch redundant sync, closes #12

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -369,10 +369,6 @@ int pthreads_store_write(zval *object, zval *key, zval *write) {
 				normal refcounting, we'll read the reference only at volatile objects
 			*/
 			rebuild_object_properties(&threaded->std);
-			
-			if(IS_PTHREADS_VOLATILE(object)) {
-				pthreads_store_sync(object);
-			}
 
 			if (Z_TYPE(member) == IS_LONG) {
 				zend_hash_index_update(threaded->std.properties, Z_LVAL(member), write);


### PR DESCRIPTION
i'm not completely sure if this is OK, but I can't think of any reason why it wouldn't be.

As far as refcounting goes, `zend_hash_update()` takes care of all scenarios I can think of.