### PR TITLE
Remove pthreads_execute_ex() hook

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -534,9 +534,7 @@ static inline zend_bool pthreads_routine_run_function(pthreads_zend_object_t* ob
 				EG(current_execute_data) = NULL;
 
 				if (EG(exception)) {
-					if (Z_TYPE(EG(user_exception_handler)) != IS_UNDEF) {
-						zend_user_exception_handler();
-					}
+					zend_try_exception_handler();
 					if (EG(exception)) {
 						zend_exception_error(EG(exception), E_ERROR);
 					}


### PR DESCRIPTION
The old workaround for #29 costed 1-2% CPU time during execution.

This new solution is a bit of a hack - it adds a fake stack frame to trick Zend into thinking that the current function is not the top frame, so that it doesn't bypass the exception handler. However, it has no performance impact.
This trick is used in a few places in php-src (notably [`zend_call_function`](https://github.com/php/php-src/blob/2d4aa1ef3d04ec85a15ae426ffdaa4f2fb0f1556/Zend/zend_execute_API.c#L622-L642) itself, and also various places within opcache.

I'm awaiting test feedback before merging this, since PM tends to find a lot more bugs than pthreads' own tests do.