### PR TITLE
Fixed memory leak of global object table

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -128,6 +128,7 @@ void pthreads_globals_shutdown() {
 		PTHREADS_G(failed)=0;
 		/* we allow proc shutdown to destroy tables, and global strings */
 		pthreads_monitor_free(PTHREADS_G(monitor));
+		zend_hash_destroy(&PTHREADS_G(objects));
 	}
 } /* }}} */
 #endif


### PR DESCRIPTION
Valgrind reports this as a leak, which is a problem because it means we can't use Valgrind for automatic leak discovery on CI, since almost all the tests fail because of this issue.