### PR TITLE
Test with Valgrind on GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,4 +81,4 @@ jobs:
 
       - name: Run PHPT tests
         run: |
-          $GITHUB_WORKSPACE/php/bin/php ./run-tests.php -P -q --show-diff -n -c $TEST_PHP_ARGS $GITHUB_WORKSPACE/php.ini
+          $GITHUB_WORKSPACE/php/bin/php ./run-tests.php $TEST_PHP_ARGS -P -q --show-diff -n -c $GITHUB_WORKSPACE/php.ini

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,3 +82,12 @@ jobs:
       - name: Run PHPT tests
         run: |
           $GITHUB_WORKSPACE/php/bin/php ./run-tests.php $TEST_PHP_ARGS -P -q --show-diff -n -c $GITHUB_WORKSPACE/php.ini
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-${{ matrix.php }}-valgrind-${{ matrix.valgrind }}
+          path: |
+            ${{ github.workspace }}/tests/*
+            !${{ github.workspace }}/tests/*.phpt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,4 +81,4 @@ jobs:
 
       - name: Run PHPT tests
         run: |
-          USE_ZEND_ALLOC=${{ matrix.zend-alloc }} $GITHUB_WORKSPACE/php/bin/php ./run-tests.php -P -q --show-diff -n -c $TEST_PHP_ARGS $GITHUB_WORKSPACE/php.ini
+          $GITHUB_WORKSPACE/php/bin/php ./run-tests.php -P -q --show-diff -n -c $TEST_PHP_ARGS $GITHUB_WORKSPACE/php.ini

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,22 +7,22 @@ on:
 
 jobs:
   build:
-    name: Tests (PHP ${{ matrix.php }}, OPcache ${{ matrix.opcache }}, ZMM ${{ matrix.zend-alloc }}, JIT ${{ matrix.jit }})
+    name: Tests (PHP ${{ matrix.php }}, OPcache ${{ matrix.opcache }}, Valgrind ${{ matrix.valgrind }}, JIT ${{ matrix.jit }})
     strategy:
       fail-fast: false
       matrix:
         php: [7.3.27, 7.4.15, 8.0.2]
         opcache: [0, 1]
-        zend-alloc: [0, 1]
+        valgrind: [0, 1]
         jit: [0]
         include:
           - php: 8.0.2
             opcache: 1
-            zend-alloc: 0
+            valgrind: 0
             jit: 1205
           - php: 8.0.2
             opcache: 1
-            zend-alloc: 1
+            valgrind: 1
             jit: 1205
 
     runs-on: ubuntu-18.04
@@ -31,12 +31,19 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      - name: Install Valgrind
+        if: matrix.valgrind == '1'
+        run: |
+          sudo apt-get update && sudo apt-get install valgrind
+          echo "TEST_PHP_ARGS=-m" >> $GITHUB_ENV
+          echo "PHP_BUILD_CONFIGURE_OPTS=--with-valgrind" >> $GITHUB_ENV
+
       - name: Restore PHP build cache
         uses: actions/cache@v2
         id: php-build-cache
         with:
           path: ${{ github.workspace }}/php 
-          key: php--${{ matrix.php }}
+          key: php-${{ matrix.php }}-valgrind-${{ matrix.valgrind }}
           
       - name: Clone php-build repository
         if: steps.php-build-cache.outputs.cache-hit != 'true'
@@ -74,4 +81,4 @@ jobs:
 
       - name: Run PHPT tests
         run: |
-          USE_ZEND_ALLOC=${{ matrix.zend-alloc }} $GITHUB_WORKSPACE/php/bin/php ./run-tests.php -P -q --show-diff -n -c $GITHUB_WORKSPACE/php.ini
+          USE_ZEND_ALLOC=${{ matrix.zend-alloc }} $GITHUB_WORKSPACE/php/bin/php ./run-tests.php -P -q --show-diff -n -c $TEST_PHP_ARGS $GITHUB_WORKSPACE/php.ini

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Run PHPT tests
         run: |
-          $GITHUB_WORKSPACE/php/bin/php ./run-tests.php $TEST_PHP_ARGS -P -q --show-diff -n -c $GITHUB_WORKSPACE/php.ini
+          $GITHUB_WORKSPACE/php/bin/php ./run-tests.php $TEST_PHP_ARGS -P -q --show-diff --show-slow 30000 -n -c $GITHUB_WORKSPACE/php.ini
 
       - name: Upload test results
         if: failure()

--- a/src/globals.c
+++ b/src/globals.c
@@ -128,6 +128,7 @@ void pthreads_globals_shutdown() {
 		PTHREADS_G(failed)=0;
 		/* we allow proc shutdown to destroy tables, and global strings */
 		pthreads_monitor_free(PTHREADS_G(monitor));
+		zend_hash_destroy(&PTHREADS_G(objects));
 	}
 } /* }}} */
 #endif

--- a/tests/class-static-properties-double-inheritance.phpt
+++ b/tests/class-static-properties-double-inheritance.phpt
@@ -26,7 +26,6 @@ abstract class ManInTheMiddle extends \Threaded{}
 error_reporting(-1);
 
 $worker->stack(new TestAsyncTask());
-while($worker->collect());
 $worker->shutdown();
 --EXPECT--
 bool(false)

--- a/tests/closure-scope-child-to-parent.phpt
+++ b/tests/closure-scope-child-to-parent.phpt
@@ -5,6 +5,8 @@ User classes on a child thread won't be available to use as a scope when a child
 Therefore, we need to reference the scope classes in a safe way that won't be affected by origin thread death.
 --XFAIL--
 This bug has not been fixed yet
+--XLEAK--
+This bug has not been fixed yet
 --FILE--
 <?php
 

--- a/tests/closures-as-members-repeated-reallocation.phpt
+++ b/tests/closures-as-members-repeated-reallocation.phpt
@@ -19,7 +19,9 @@ $worker->start();
 while ($count++ < 1000) {
     $function = new TestClosure(function() {});
     $worker->stack($function);
-    while($worker->collect());
+    while($worker->collect()){
+        usleep(1);
+    }
 }
 var_dump('ok');
 --EXPECTF--

--- a/tests/new-class-after-thread-creation.phpt
+++ b/tests/new-class-after-thread-creation.phpt
@@ -13,6 +13,5 @@ interface A {}
 class task extends Threaded implements A {}
 
 $worker->stack(new task());
-while($worker->collect());
 $worker->shutdown();
 --EXPECT--

--- a/tests/volatile-nested.phpt
+++ b/tests/volatile-nested.phpt
@@ -26,12 +26,22 @@ class TestNestedWrite extends Thread {
         $this->shared['queue'][0] = new Volatile();
 
         $this->shared['lock'] = true;
+        $this->shared->synchronized(function() : void{
+            $this->shared->notify();
+        });
 
-        while(!isset($this->shared['lock2'])) {}
+        $this->shared->synchronized(function() : void{
+            while(!isset($this->shared['lock2'])) {
+                $this->shared->wait();
+            }
+        });
 
         var_dump($this->shared['queue'][1]);
 
         $this->shared['lock3'] = true;
+        $this->shared->synchronized(function() : void{
+            $this->shared->notify();
+        });
     }
 }
 
@@ -43,14 +53,25 @@ class TestNestedRead extends Thread {
     }
 
     public function run() {
-        while(!isset($this->shared['lock']));
+        $this->shared->synchronized(function() : void{
+            while(!isset($this->shared['lock'])){
+                $this->shared->wait();
+            }
+        });
 
         var_dump($this->shared['queue'][1]);
 
         $this->shared['queue'][1] = new Node();
         $this->shared['lock2'] = true;
+        $this->shared->synchronized(function() : void{
+            $this->shared->notify();
+        });
 
-        while(!isset($this->shared['quit']));
+        $this->shared->synchronized(function() : void{
+            while(!isset($this->shared['quit'])){
+                $this->shared->wait();
+            }
+        });
     }
 }
 
@@ -68,9 +89,16 @@ class Test extends Thread {
         $thread2 = new TestNestedRead($shared);
         $thread2->start();
 
-        while(!isset($shared['lock3']));
+        $shared->synchronized(function() use ($shared) : void{
+            while(!isset($shared['lock3'])){
+                $shared->wait();
+            }
+        });
 
         $shared['quit'] = true;
+        $shared->synchronized(function() use ($shared) : void{
+            $shared->notify();
+        });
 
         $thread2->join();
         $thread->join();


### PR DESCRIPTION
This required changes to several tests, which became prohibitively slow under Valgrind due to unnecessary (and extremely costly) spin-locks.

Valgrind runs take significantly longer than non-Valgrind runs, but this should enable quicker detection of memory leaks and general bugs in the code (assuming that the tests actually reproduce them).