### PR TITLE
Begin imposing hard limits on closures (#97)

### DIFF
--- a/src/store_types.h
+++ b/src/store_types.h
@@ -38,6 +38,7 @@ typedef struct _pthreads_storage {
 typedef struct _pthreads_closure_storage_t {
 	pthreads_storage common;
 	zend_closure* closure;
+	pthreads_zend_object_t* this_obj;
 	pthreads_ident_t owner;
 } pthreads_closure_storage_t;
 

--- a/tests/closure-nts-this.phpt
+++ b/tests/closure-nts-this.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test that closures with non-thread-safe $this cannot be assigned to thread-safe objects
+--DESCRIPTION--
+We weren't copying closure $this, causing them to suddenly become NULL on the destination thread.
+We might be able to copy $this if $this is a thread-safe object, but in all other cases, this won't be possible.
+The limitations of this must be made clear with clear errors.
+--FILE--
+<?php
+
+class A{
+	public function getClosure() : \Closure{
+		return function() : void{
+			var_dump($this);
+		};
+	}
+}
+
+$a = new A();
+$closure = $a->getClosure();
+
+$t = new \ThreadedArray();
+try{
+	$t["closure"] = $closure;
+}catch(\Error $e){
+	echo $e->getMessage() . PHP_EOL;
+}
+
+?>
+--EXPECT--
+Cannot assign non-thread-safe value of type object to ThreadedArray

--- a/tests/closure-static-variables.phpt
+++ b/tests/closure-static-variables.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test that Closures with static variables cannot be assigned to thread-safe objects
+--DESCRIPTION--
+We can't prevent static variables from gaining non-thread-safe static variable values after assignment to thread-safe objects, so they must be completely prohibited.
+--FILE--
+<?php
+
+$func = function() : void{
+	static $a = 1;
+	$a++;
+	var_dump($a);
+};
+
+$array = new \ThreadedArray();
+try{
+	$array["func"] = $func;
+}catch(\Error $e){
+	echo $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+Cannot assign non-thread-safe value of type object to ThreadedArray

--- a/tests/closure-ts-this.phpt
+++ b/tests/closure-ts-this.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test that closures with thread-safe $this work correctly
+--DESCRIPTION--
+We weren't copying closure $this, causing them to suddenly become NULL on the destination thread.
+Since the closure's $this is thread-safe, it should be restored onto the destination thread without issues.
+--FILE--
+<?php
+
+class A extends \ThreadedBase{
+	public function getClosure() : \Closure{
+		return function() : void{
+			var_dump($this);
+		};
+	}
+}
+
+$a = new A();
+$closure = $a->getClosure();
+
+$thread = new class($closure) extends \Thread{
+	public function __construct(private \Closure $closure){}
+
+	public function run() : void{
+		var_dump($this->closure);
+	}
+};
+
+$thread->start();
+$thread->join();
+
+?>
+--EXPECT--
+object(Closure)#3 (1) {
+  ["this"]=>
+  object(A)#2 (0) {
+  }
+}

--- a/tests/closure-use-by-ref.phpt
+++ b/tests/closure-use-by-ref.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test that Closures with use() by reference cannot be assigned to thread-safe objects
+--DESCRIPTION--
+Use-by-reference cannot be allowed to operate across threads due to safety issues, so closures using references must be rejected clearly.
+--FILE--
+<?php
+
+$a = 1;
+$func = function() use (&$a) : void{
+	$a++;
+	var_dump($a);
+};
+
+$array = new \ThreadedArray();
+try{
+	$array["func"] = $func;
+}catch(\Error $e){
+	echo $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+Cannot assign non-thread-safe value of type object to ThreadedArray


### PR DESCRIPTION
This change:
- prohibits non-static closures with a non-thread-safe $this bound
- restores $this onto target threads if $this is a thread-safe object
- disallows the use of static variables inside copied closures
- disallows the use of use-by-reference

There are a bunch more changes that need to be done, but this is a good start.