### PR TITLE
Readonly properties

### DIFF
--- a/src/store.h
+++ b/src/store.h
@@ -34,6 +34,13 @@ typedef struct _pthreads_store_t {
 	zend_long modcount;
 } pthreads_store_t;
 
+typedef enum {
+	WRITE_SUCCESS = 0,
+	WRITE_FAIL_UNKNOWN = -1,
+	WRITE_FAIL_NOT_THREAD_SAFE = -2,
+	WRITE_FAIL_WOULD_OVERWRITE = -3
+} pthreads_store_write_result;
+
 void pthreads_store_init(pthreads_store_t* store);
 void pthreads_store_destroy(pthreads_store_t* store);
 void pthreads_store_sync_local_properties(zend_object* object);
@@ -41,8 +48,10 @@ void pthreads_store_full_sync_local_properties(zend_object *object);
 int pthreads_store_merge(zend_object *destination, zval *from, zend_bool overwrite, zend_bool coerce_array_to_threaded);
 int pthreads_store_delete(zend_object *object, zval *key);
 int pthreads_store_read(zend_object *object, zval *key, int type, zval *read);
+int pthreads_store_read_local_property(zend_object* object, zend_string* key, int type, zval* read);
 zend_bool pthreads_store_isset(zend_object *object, zval *key, int has_set_exists);
 int pthreads_store_write(zend_object *object, zval *key, zval *write, zend_bool coerce_array_to_threaded);
+pthreads_store_write_result pthreads_store_write_ex(zend_object *object, zval *key, zval *write, zend_bool coerce_array_to_threaded, zend_bool overwrite);
 void pthreads_store_tohash(zend_object *object, HashTable *hash);
 int pthreads_store_shift(zend_object *object, zval *member);
 int pthreads_store_chunk(zend_object *object, zend_long size, zend_bool preserve, zval *chunk);

--- a/tests/readonly-properties-thread-safe.phpt
+++ b/tests/readonly-properties-thread-safe.phpt
@@ -1,0 +1,137 @@
+--TEST--
+Test that readonly properties behave as expected on thread-safe class descendents
+--DESCRIPTION--
+pthreads doesn't (yet) mirror the exact behaviour of readonly properties on standard objects
+for now, this test just ensures that the behaviour plays out as expected with lockless reads,
+since those use local cache without locks if possible.
+--SKIPIF--
+<?php if(PHP_VERSION_ID < 80100) die("skip readonly properties are only supported in 8.1 and up"); ?>
+--FILE--
+<?php
+
+class T extends \ThreadedBase{
+	public readonly int $a;
+
+	public readonly \ThreadedArray $array;
+
+	public readonly int $initiallyUninit;
+
+	public function __construct(){
+		$this->a = 1;
+		$this->array = new \ThreadedArray();
+	}
+
+	public function unsetProperties() : void{
+		try{
+			unset($this->a);
+		}catch(\Error $e){
+			echo $e->getMessage() . PHP_EOL;
+		}
+		try{
+			unset($this->array);
+		}catch(\Error $e){
+			echo $e->getMessage() . PHP_EOL;
+		}
+		try{
+			unset($this->initiallyUninit);
+		}catch(\Error $e){
+			echo $e->getMessage() . PHP_EOL;
+		}
+	}
+
+	public function writeProperties() : void{
+		try{
+			$this->a = 2;
+		}catch(\Error $e){
+			echo $e->getMessage() . PHP_EOL;
+		}
+		try{
+			$this->a++;
+		}catch(\Error $e){
+			echo $e->getMessage() . PHP_EOL;
+		}
+		try{
+			$this->array = new \ThreadedArray();
+		}catch(\Error $e){
+			echo $e->getMessage() . PHP_EOL;
+		}
+		try{
+			$this->initiallyUninit = 2;
+		}catch(\Error $e){
+			echo $e->getMessage() . PHP_EOL;
+		}
+	}
+
+	public function readProperties() : void{
+		var_dump($this->a);
+		var_dump($this->array);
+		var_dump($this->initiallyUninit);
+	}
+
+	public function issetProperties() : void{
+		var_dump(isset($this->a));
+		var_dump(isset($this->array));
+		var_dump(isset($this->initiallyUninit));
+	}
+}
+
+function test(T $t) : void{
+	//these must run first, to ensure they work on an unpopulated local cache
+	$t->unsetProperties();
+	$t->writeProperties();
+	$t->issetProperties();
+	$t->readProperties();
+}
+
+echo "--- main thread start ---\n";
+test(new T());
+echo "--- main thread end ---\n";
+
+//init properties from the main thread - ensure that the child thread receives an empty local cache
+$thread = new class(new T) extends \Thread{
+	public function __construct(
+		private T $t
+	){}
+
+	public function run() : void{
+		echo "--- child thread start ---\n";
+		test($this->t);
+		echo "--- child thread end ---\n";
+	}
+};
+$thread->start();
+$thread->join();
+echo "OK\n";
+?>
+--EXPECTF--
+--- main thread start ---
+Cannot unset readonly property T::$a
+Cannot unset readonly property T::$array
+Cannot unset readonly property T::$initiallyUninit
+Cannot modify readonly property T::$a
+Cannot modify readonly property T::$a
+Cannot modify readonly property T::$array
+bool(true)
+bool(true)
+bool(true)
+int(1)
+object(ThreadedArray)#%d (0) {
+}
+int(2)
+--- main thread end ---
+--- child thread start ---
+Cannot unset readonly property T::$a
+Cannot unset readonly property T::$array
+Cannot unset readonly property T::$initiallyUninit
+Cannot modify readonly property T::$a
+Cannot modify readonly property T::$a
+Cannot modify readonly property T::$array
+bool(true)
+bool(true)
+bool(true)
+int(1)
+object(ThreadedArray)#%d (0) {
+}
+int(2)
+--- child thread end ---
+OK


### PR DESCRIPTION
Before this, readonly was silently ignored, so properties would be
treated the same as normal properties.

This change enforces write-once and no-unset policies for readonly
properties.

It also permits lockless reads of locally cached property values of readonly properties, since these can't be changed by another thread after initialization. This offers a performance benefit for objects whose properties are frequently accessed by multiple threads by reducing lock contention.

Currently this only covers stuff that is kept in the local cache, such
as thread-safe objects, closures, sockets and strings. The cache could
be extended to more stuff to permit this optimisation to apply to other
types of properties, but that's a task for another time.