### PR TITLE
Thread::start() now requires options to be specified

### DIFF
--- a/classes/pool.c
+++ b/classes/pool.c
@@ -174,7 +174,10 @@ Pool_method(submit) {
 					zval_dtor(&retval);
 			}
 
-			zend_call_method(Z_OBJ_P(&worker), Z_OBJCE(worker), NULL, ZEND_STRL("start"), NULL, 0, NULL, NULL);
+			zval options;
+			ZVAL_LONG(&options, PMMPTHREAD_INHERIT_ALL); //TODO: allow this to be provided by the constructor
+
+			zend_call_method_with_1_params(Z_OBJ_P(&worker), Z_OBJCE(worker), NULL, "start", NULL, &options);
 		}
 
 		selected = zend_hash_index_update(

--- a/classes/thread.c
+++ b/classes/thread.c
@@ -22,16 +22,15 @@
 
 #define Thread_method(name) PHP_METHOD(pmmp_thread_Thread, name)
 
-/* {{{ proto boolean Thread::start([long $options = Thread::INHERIT_ALL])
+/* {{{ proto boolean Thread::start([long $options])
 		Starts executing the implementations run method in a thread, will return a boolean indication of success
 		$options should be a mask of inheritance constants */
 Thread_method(start)
 {
 	pmmpthread_zend_object_t* thread = PMMPTHREAD_FETCH;
-	zend_long options = PMMPTHREAD_INHERIT_ALL;
+	zend_long options;
 
-	ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 0, 1)
-		Z_PARAM_OPTIONAL
+	ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 1)
 		Z_PARAM_LONG(options)
 	ZEND_PARSE_PARAMETERS_END();
 

--- a/examples/Benchmark.php
+++ b/examples/Benchmark.php
@@ -29,7 +29,7 @@ do {
     $ts = [];
     while (count($ts)<$max) {
         $t = new MyThread();
-        $t->start();
+        $t->start(Thread::INHERIT_ALL); //TODO: customizable option args?
         $ts[]=$t;
     }
     $ts = [];

--- a/examples/CallAnyFunction.php
+++ b/examples/CallAnyFunction.php
@@ -29,6 +29,8 @@ class Caller extends Thread {
 	* The smallest thread in the world
 	**/
 	public function run() : void{
+		/* You should include vendor/autoload.php or other autoloader before doing anything here */
+
 		$this->result = 
 			($this->method)(...unserialize($this->params)); /* gotta love php7 :) */
 	}
@@ -38,7 +40,13 @@ class Caller extends Thread {
 	**/
 	public static function call($method, ...$params){
 		$thread = new Caller($method, ...$params);
-		if($thread->start()){
+
+		/*
+		 * You really, really don't want to use INHERIT_ALL in a production application - it's really slow and wastes lots of memory
+		 * Prefer INHERIT_NONE if you can autoload your code and don't set any INI entries
+		 * In this example code, it's used because we're in a single-file script and don't have an autoloader
+		 */
+		if($thread->start(Thread::INHERIT_ALL)){
 			return $thread;
 		}
 	}

--- a/examples/ClosureFuture.php
+++ b/examples/ClosureFuture.php
@@ -37,7 +37,13 @@ class Future extends Thread {
     public static function of(Closure $closure, array $args = []) {
         $future = 
             new self($closure, $args);
-        $future->start();
+
+        /*
+         * You really, really don't want to use INHERIT_ALL in a production application - it's really slow and wastes lots of memory
+         * Prefer INHERIT_NONE if you can autoload your code and don't set any INI entries
+         * In this example code, it's used because we're in a single-file script and don't have an autoloader
+         */
+        $future->start(Thread::INHERIT_ALL);
         return $future;
     }
     

--- a/examples/KeepAliveSession.php
+++ b/examples/KeepAliveSession.php
@@ -185,6 +185,12 @@ if ($socket) {
     
     while (++ $worker < 5) {
         $workers[$worker] = new Test($socket);
+
+        /*
+         * You really, really don't want to use INHERIT_ALL in a production application - it's really slow and wastes lots of memory
+         * Prefer INHERIT_NONE if you can autoload your code and don't set any INI entries
+         * In this example code, it's used because we're in a single-file script and don't have an autoloader
+         */
         $workers[$worker]->start(Thread::INHERIT_ALL|Thread::ALLOW_HEADERS);
     }
     

--- a/examples/ObjectsAsParameters.php
+++ b/examples/ObjectsAsParameters.php
@@ -81,7 +81,11 @@ $request = new Request($response);
 * Tell you all about it ...
 */
 printf("Fetching: %s ", $response->getUrl());
-if($request->start()){
+/*
+ * This is using INHERIT_ALL because we are in a single-file script, but you should
+ * prefer INHERIT_NONE (or perhaps INHERIT_INI) if you can autoload your code.
+ */
+if($request->start(Thread::INHERIT_ALL)){
 	/* do something during runtime */
 	while($request->isRunning()) {
 		echo ".";

--- a/examples/SelectiveInheritance.php
+++ b/examples/SelectiveInheritance.php
@@ -1,12 +1,15 @@
 <?php
 /*
-* This is for advanced users ONLY !!
-*
 * In a large application, the overhead of each thread having to copy the entire context may become undesireable.
 * Selective Inheritance serves as a way to choose which parts of the environment are available in threading contexts
 * Following is some code that demonstrates the use of this feature
 *
 * Note: the included_files table is only populated where Thread::INHERIT_INCLUDES is set
+*
+* Ideally you want to inherit as little stuff as possible. Inheriting INI is fine, but generally speaking,
+* you should avoid inheriting classes/functions/constants if they can be autoloaded, as inheriting code will use a lot
+* of memory, as well as making thread startup slower.
+* Code inheritance is supported for the cases where this isn't possible, such as single-file scripts like the one below.
 */
 
 use pmmp\thread\Thread;
@@ -37,6 +40,10 @@ expect:
     bool(false)
 <?php
 $test = new Selective();
+/*
+ * this is the most performant option and should be used wherever possible
+ * if all your code can be autoloaded you should be able to use this
+ */
 $test->start(Thread::INHERIT_NONE);
 $test->join();
 ?>
@@ -67,6 +74,10 @@ expect:
     bool(true)
 <?php
 $test = new Selective();
-$test->start();
+/*
+ * You really, really don't want to use INHERIT_ALL in a production application - it's really slow and wastes lots of memory
+ * Prefer INHERIT_NONE if you can autoload your code and don't set any INI entries
+ */
+$test->start(Thread::INHERIT_ALL);
 $test->join();
 ?>

--- a/examples/SimpleWebRequest.php
+++ b/examples/SimpleWebRequest.php
@@ -25,8 +25,11 @@ class WebRequest extends Thread {
 
 $t = microtime(true);
 $g = new WebRequest(sprintf("http://www.google.com/?q=%s", rand()*10));
-/* starting synchronized */
-if($g->start()){
+/*
+ * starting synchronized
+ * we can use INHERIT_NONE here for faster thread start, since the thread doesn't use any code apart from itself and PHP built-in functions
+ */
+if($g->start(Thread::INHERIT_NONE)){
 	printf("Request took %f seconds to start ", microtime(true)-$t);
 	while($g->isRunning()){
 		echo ".";

--- a/examples/SocketServer.php
+++ b/examples/SocketServer.php
@@ -5,7 +5,9 @@ use pmmp\thread\Thread;
 class Client extends Thread {
 	public function __construct($socket){
 		$this->socket = $socket;
-		$this->start();
+
+		/* INHERIT_NONE can be used if the thread doesn't need any code that can't be autoloaded */
+		$this->start(Thread::INHERIT_NONE);
 	}
 	public function run() : void {
 		$client = $this->socket;

--- a/examples/Sockets.php
+++ b/examples/Sockets.php
@@ -24,7 +24,8 @@ $sock = socket_create_listen($argv[1]);
 if ($sock) {	
 	while(++$worker<5){
 		$workers[$worker] = new Test($sock);
-		$workers[$worker]->start();
+		/* we can use INHERIT_NONE here since the thread isn't using any other code */
+		$workers[$worker]->start(Thread::INHERIT_NONE);
 	}
 	printf("%d threads waiting on port %d\n", count($workers), $argv[1]);
 }

--- a/examples/Synchronization.php
+++ b/examples/Synchronization.php
@@ -48,7 +48,9 @@ class GoodCode extends Thread{
 }
 $thread = new GoodCode();
 
-$thread->start();
+/* this thread isn't using any other code - we can use INHERIT_NONE */
+$thread->start(Thread::INHERIT_NONE);
+
 /*
  * wait() can ONLY be reliably used inside a synchronized block on the SAME ThreadSafe object that you're synchronizing with.
  * The behaviour of wait() is undefined if used outside a synchronized() block on the same object that you're wait()ing on.

--- a/examples/ThreadSafeArray.php
+++ b/examples/ThreadSafeArray.php
@@ -19,7 +19,8 @@ $hammers = 500;
 class T extends Thread {
 	public function __construct($test){
 		$this->test = $test;
-		$this->start();
+		/* this thread isn't using any other code - we can use INHERIT_NONE */
+		$this->start(Thread::INHERIT_NONE);
 	}
 	public function run() : void{
 		/*

--- a/stubs/Thread.stub.php
+++ b/stubs/Thread.stub.php
@@ -164,5 +164,5 @@ abstract class Thread extends Runnable
      *
      * @return bool A boolean indication of success
      */
-    public function start(int $options = Thread::INHERIT_ALL) : bool{}
+    public function start(int $options) : bool{}
 }

--- a/stubs/Thread_arginfo.h
+++ b/stubs/Thread_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d085d48e578355ff4b1de837439458f6ea88f5fb */
+ * Stub hash: 0a3b5a02d5c1fb06895fc206d5193f3a223343ce */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_pmmp_thread_Thread_getCreatorId, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -18,8 +18,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_pmmp_thread_Thread_join arginfo_class_pmmp_thread_Thread_isJoined
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_pmmp_thread_Thread_start, 0, 0, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "pmmp\\thread\\Thread::INHERIT_ALL")
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_pmmp_thread_Thread_start, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, options, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 

--- a/tests/anon-bound-inherited.phpt
+++ b/tests/anon-bound-inherited.phpt
@@ -24,7 +24,7 @@ $collectable = new class extends \pmmp\thread\Runnable {
 	}
 };
 
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 $worker->stack($collectable);
 $worker->shutdown();
 --EXPECT--

--- a/tests/anon-interceptors.phpt
+++ b/tests/anon-interceptors.phpt
@@ -42,7 +42,7 @@ class Test extends \pmmp\thread\Thread {
     }
 }
 $thread = new Test();
-$thread->start() && $thread->join();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL) && $thread->join();
 --EXPECT--
 string(16) "Foo::__construct"
 string(16) "Bar::__construct"

--- a/tests/anon-unbound-bound-on-child-thread.phpt
+++ b/tests/anon-unbound-bound-on-child-thread.phpt
@@ -96,7 +96,7 @@ function test(){
 	var_dump($anon::$myOwnStaticProp);
 }
 $worker = new \pmmp\thread\Worker();
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 $worker->stack(new class extends \pmmp\thread\Runnable{
 	public function run() : void{
 		echo "--- worker thread start ---\n";

--- a/tests/anon-unbound-double-inherited.phpt
+++ b/tests/anon-unbound-double-inherited.phpt
@@ -36,7 +36,7 @@ trait T1 {function t(){}}
 trait T2 {function t(){}}
 
 $w = new \pmmp\thread\Worker();
-$w->start();
+$w->start(\pmmp\thread\Thread::INHERIT_ALL);
 $w->stack(/** b */new class extends C {});
 $w->shutdown();
 --EXPECT--

--- a/tests/anon-unbound-inherited-constants.phpt
+++ b/tests/anon-unbound-inherited-constants.phpt
@@ -7,7 +7,7 @@ from copied versions of the anonymous class.
 <?php
 $worker = new \pmmp\thread\Worker();
 
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 interface Dummy {
 	public const A_CONSTANT = 1;

--- a/tests/anon-unbound-inherited-interfaces.phpt
+++ b/tests/anon-unbound-inherited-interfaces.phpt
@@ -8,7 +8,7 @@ cause the anonymous class to have more interfaces after linking.
 <?php
 $worker = new \pmmp\thread\Worker();
 
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 interface Dummy {
 }

--- a/tests/anon-unbound-inherited-properties.phpt
+++ b/tests/anon-unbound-inherited-properties.phpt
@@ -7,7 +7,7 @@ be available on the copied versions of anonymous classes.
 <?php
 $worker = new \pmmp\thread\Worker();
 
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 class Base extends \pmmp\thread\Runnable {
 	public static $staticProp = "staticProp";

--- a/tests/anon-unbound-inherited.phpt
+++ b/tests/anon-unbound-inherited.phpt
@@ -6,7 +6,7 @@ This test verifies that anonymous ThreadSafe objects work as expected
 <?php
 $worker = new \pmmp\thread\Worker();
 
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 $collectable = new class extends \pmmp\thread\Runnable {
 	/** z */

--- a/tests/anon-unbound-use-guards.phpt
+++ b/tests/anon-unbound-use-guards.phpt
@@ -16,7 +16,7 @@ class T2 extends \pmmp\thread\Runnable
 }
 
 $w = new \pmmp\thread\Worker();
-$w->start();
+$w->start(\pmmp\thread\Thread::INHERIT_ALL);
 $w->stack(new class extends T2 {});
 $w->shutdown();
 --EXPECT--

--- a/tests/argc-argv.phpt
+++ b/tests/argc-argv.phpt
@@ -14,7 +14,7 @@ $t = new class extends \pmmp\thread\Thread{
 		var_dump($argc, $argv);
 	}
 };
-$t->start();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL);
 ?>
 --EXPECTF--
 int(2)

--- a/tests/binding.phpt
+++ b/tests/binding.phpt
@@ -39,7 +39,7 @@ $threads[1]=new ThreadTest();
 $threads[0]->setOther($threads[1]);
 $threads[1]->setOther($threads[0]);
 foreach($threads as $thread)
-	$thread->start();
+	$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 foreach($threads as $thread) {
 	$thread->synchronized(function() use($thread){
 		if (!$thread->done)

--- a/tests/cached-full-sync.phpt
+++ b/tests/cached-full-sync.phpt
@@ -18,7 +18,7 @@ $t1 = new class($array) extends \pmmp\thread\Thread{
 		$this->array[] = new \pmmp\thread\ThreadSafeArray();
 	}
 };
-$t1->start() && $t1->join();
+$t1->start(\pmmp\thread\Thread::INHERIT_ALL) && $t1->join();
 
 var_dump($array);
 ?>

--- a/tests/callstatic-etc.phpt
+++ b/tests/callstatic-etc.phpt
@@ -17,7 +17,7 @@ class UserThread extends \pmmp\thread\Thread {
 }
 
 $thread = new UserThread;
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 ?>
 --EXPECT--
 string(11) "called_func"

--- a/tests/child-thread-to-parent-threaded-dereferencing.phpt
+++ b/tests/child-thread-to-parent-threaded-dereferencing.phpt
@@ -19,7 +19,7 @@ $worker = new class extends \pmmp\thread\Thread{
 		$this->array["recursive"] = $this->array;
 	}
 };
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 $worker->join();
 var_dump($worker);
 ?>

--- a/tests/child-to-parent-class-copying.phpt
+++ b/tests/child-to-parent-class-copying.phpt
@@ -29,7 +29,7 @@ class Foo extends \pmmp\thread\Thread
 
 $foo = new Foo();
 $foo->shared = new \pmmp\thread\ThreadSafeArray();
-$foo->start();
+$foo->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 $foo->synchronized(function() use ($foo) : void{
 	while(!isset($foo->shared['baseClass'])){

--- a/tests/child-to-parent-values-copying.phpt
+++ b/tests/child-to-parent-values-copying.phpt
@@ -20,7 +20,7 @@ class Test extends \pmmp\thread\Thread{
 	}
 }
 $t = new Test();
-$t->start() && $t->join();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL) && $t->join();
 
 var_dump($t);
 ?>

--- a/tests/child-worker-to-parent-threaded-dereferencing.phpt
+++ b/tests/child-worker-to-parent-threaded-dereferencing.phpt
@@ -11,7 +11,7 @@ This test verifies that this behaviour works as intended.
 <?php
 
 $worker = new \pmmp\thread\Worker();
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 $worker->stack(new class extends \pmmp\thread\Runnable{
 	public \pmmp\thread\ThreadSafeArray $array;

--- a/tests/class-attributes.phpt
+++ b/tests/class-attributes.phpt
@@ -93,7 +93,7 @@ $thread = new class extends \pmmp\thread\Thread{
 		echo "--- child thread end ---\n";
 	}
 };
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 $thread->join();
 echo "OK\n";
 ?>

--- a/tests/class-defaults.phpt
+++ b/tests/class-defaults.phpt
@@ -20,7 +20,7 @@ class Test extends \pmmp\thread\Thread {
 }
 
 $test =new Test();
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->join();
 ?>
 --EXPECT--

--- a/tests/class-static-properties-double-inheritance.phpt
+++ b/tests/class-static-properties-double-inheritance.phpt
@@ -6,7 +6,7 @@ This is yet another variation of static properties that has highlighted regressi
 <?php
 
 $worker = new \pmmp\thread\Worker();
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 class TestAsyncTask extends ManInTheMiddle {
 	public static $destroyed = false;

--- a/tests/closure-delayed-include.phpt
+++ b/tests/closure-delayed-include.phpt
@@ -36,7 +36,7 @@ class Foo extends \pmmp\thread\Thread {
 $shared = new \pmmp\thread\ThreadSafeArray();
 
 $foo = new Foo($shared);
-$foo->start();
+$foo->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 $foo->synchronized(function() use ($foo, $shared) : void{
     while(!isset($shared['loader'])) {

--- a/tests/closure-scope-child-to-parent.phpt
+++ b/tests/closure-scope-child-to-parent.phpt
@@ -20,7 +20,7 @@ $t = new class extends \pmmp\thread\Thread{
 	}
 };
 
-$t->start() && $t->join();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL) && $t->join();
 ($t->closure)();
 echo "OK\n";
 ?>

--- a/tests/closure-scope.phpt
+++ b/tests/closure-scope.phpt
@@ -35,7 +35,7 @@ $t = new class extends \pmmp\thread\Thread{
 	}
 };
 $t->closure = $closure;
-$t->start() && $t->join();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL) && $t->join();
 ?>
 --EXPECT--
 string(1) "B"

--- a/tests/closure-secondary-thread-copy.phpt
+++ b/tests/closure-secondary-thread-copy.phpt
@@ -25,7 +25,7 @@ $thread = new class extends \pmmp\thread\Thread {
     }
 };
 
-$thread->start() && $thread->join();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL) && $thread->join();
 echo "OK\n";
 --EXPECT--
 OK

--- a/tests/closure-ts-this.phpt
+++ b/tests/closure-ts-this.phpt
@@ -25,7 +25,7 @@ $thread = new class($closure) extends \pmmp\thread\Thread{
 	}
 };
 
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 $thread->join();
 
 ?>

--- a/tests/closures-as-members-repeated-reallocation.phpt
+++ b/tests/closures-as-members-repeated-reallocation.phpt
@@ -15,7 +15,7 @@ class TestClosure extends \pmmp\thread\Runnable {
 }
 $count = 0;
 $worker = new \pmmp\thread\Worker();
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 while ($count++ < 1000) {
     $function = new TestClosure(function() {});
     $worker->stack($function);

--- a/tests/closures-as-members.phpt
+++ b/tests/closures-as-members.phpt
@@ -48,7 +48,7 @@ class T extends \pmmp\thread\Thread {
 
 /* start thread to call closure */
 $t = new T($test);
-$t->start();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 /* wait for new closure */
 $t->synchronized(function() use($t) {

--- a/tests/complex-statics-set-null.phpt
+++ b/tests/complex-statics-set-null.phpt
@@ -38,7 +38,7 @@ file::get("something".(++$i));
 file::get("something".(++$i));
 
 $thread = new UserThread();
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 $thread->join();
 ?>
 --EXPECTF--

--- a/tests/complex-statics.phpt
+++ b/tests/complex-statics.phpt
@@ -36,7 +36,7 @@ sql::query("SELECT * FROM mysql.user");
 sql::query("SELECT * FROM mysql.user");
 
 $thread = new UserThread();
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 ?>
 --EXPECT--
 sql::_query: SELECT * FROM mysql.user

--- a/tests/constant-array.phpt
+++ b/tests/constant-array.phpt
@@ -11,7 +11,7 @@ class Test extends \pmmp\thread\Thread {
 }
 
 $test = new Test();
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->join();
 --EXPECT--
 ok

--- a/tests/constant-ast-copy-missing-type.phpt
+++ b/tests/constant-ast-copy-missing-type.phpt
@@ -20,7 +20,7 @@ namespace {
 	use any\name\space\Test;
 
 	$objTest = new Test();
-	$objTest->start();
+	$objTest->start(\pmmp\thread\Thread::INHERIT_ALL);
 	$objTest->join();
 }
 ?>

--- a/tests/constant-ast-copy.phpt
+++ b/tests/constant-ast-copy.phpt
@@ -18,7 +18,7 @@ $t = new class extends \pmmp\thread\Thread {
     }
 };
 
-$t->start() && $t->join();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL) && $t->join();
 ?>
 --EXPECTF--
 Fatal error: Uncaught Exception in %s:12

--- a/tests/constants.phpt
+++ b/tests/constants.phpt
@@ -9,7 +9,7 @@ class TestThread extends \pmmp\thread\Thread {
 }
 
 $thread = new TestThread();
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 ?>
 --EXPECT--
 Y-m-d\TH:i:sO

--- a/tests/display-startup-errors-output.phpt
+++ b/tests/display-startup-errors-output.phpt
@@ -17,7 +17,7 @@ function undefined(){
 }
 
 $w = new \pmmp\thread\Worker();
-$w->start();
+$w->start(\pmmp\thread\Thread::INHERIT_ALL);
 $w->stack(new class extends \pmmp\thread\Runnable{
 	public function run() : void{
 		throwException();
@@ -26,7 +26,7 @@ $w->stack(new class extends \pmmp\thread\Runnable{
 $w->shutdown();
 
 $w = new \pmmp\thread\Worker();
-$w->start();
+$w->start(\pmmp\thread\Thread::INHERIT_ALL);
 $w->stack(new class extends \pmmp\thread\Runnable{
 	public function run() : void{
 		undefined();

--- a/tests/doc-comments.phpt
+++ b/tests/doc-comments.phpt
@@ -33,7 +33,7 @@ class T extends \pmmp\thread\Thread {
 }
 
 $t = new T();
-$t->start();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL);
 $t->join();
 
 $reflect = new ReflectionMethod("T", "run");

--- a/tests/duplicate-connections-on-creator.phpt
+++ b/tests/duplicate-connections-on-creator.phpt
@@ -39,7 +39,7 @@ class Dummy extends \pmmp\thread\Runnable{
 		});
 	}
 }
-$w->start();
+$w->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 echo "first task\n";
 $w->stack($t = new Dummy);

--- a/tests/enum-member-copy.phpt
+++ b/tests/enum-member-copy.phpt
@@ -22,7 +22,7 @@ $t = new class extends \pmmp\thread\Thread{
 	}
 };
 
-$t->start() && $t->join();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL) && $t->join();
 
 ?>
 --EXPECT--

--- a/tests/enums-backed-preinit.phpt
+++ b/tests/enums-backed-preinit.phpt
@@ -24,7 +24,7 @@ $t = new class extends \pmmp\thread\Thread{
 		test();
 	}
 };
-$t->start() && $t->join();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL) && $t->join();
 
 ?>
 --EXPECT--

--- a/tests/enums-backed.phpt
+++ b/tests/enums-backed.phpt
@@ -22,7 +22,7 @@ $t = new class extends \pmmp\thread\Thread{
 		test();
 	}
 };
-$t->start() && $t->join();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL) && $t->join();
 
 test();
 

--- a/tests/enums-basic-preinit.phpt
+++ b/tests/enums-basic-preinit.phpt
@@ -23,7 +23,7 @@ $t = new class extends \pmmp\thread\Thread{
 		test();
 	}
 };
-$t->start() && $t->join();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL) && $t->join();
 
 ?>
 --EXPECT--

--- a/tests/enums-basic.phpt
+++ b/tests/enums-basic.phpt
@@ -21,7 +21,7 @@ $t = new class extends \pmmp\thread\Thread{
 		test();
 	}
 };
-$t->start() && $t->join();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL) && $t->join();
 
 test();
 

--- a/tests/exception-handler-caught-nested.phpt
+++ b/tests/exception-handler-caught-nested.phpt
@@ -22,7 +22,7 @@ class Test extends \pmmp\thread\Thread {
     }
 }
 $test = new Test();
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->join();
 --EXPECTF--
 string(6) "Caught"

--- a/tests/exception-handler-caught-uncaught.phpt
+++ b/tests/exception-handler-caught-uncaught.phpt
@@ -22,7 +22,7 @@ class Test extends \pmmp\thread\Thread {
 }
 
 $test = new Test();
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->join();
 --EXPECTF--
 string(6) "Caught"

--- a/tests/fake-closure-static-variables.phpt
+++ b/tests/fake-closure-static-variables.phpt
@@ -51,7 +51,7 @@ $t = new class($fcc, $fcc2) extends \pmmp\thread\Thread{
 		test2($this->fcc2);
 	}
 };
-$t->start();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL);
 $t->join();
 
 ?>

--- a/tests/foreign-private-members.phpt
+++ b/tests/foreign-private-members.phpt
@@ -24,7 +24,7 @@ class TEST extends \pmmp\thread\Thread {
 
 $my = new MY();
 $test = new TEST($my);
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 --EXPECT--
 TEST: Hello World
 

--- a/tests/function-attributes.phpt
+++ b/tests/function-attributes.phpt
@@ -60,7 +60,7 @@ $thread = new class extends \pmmp\thread\Thread{
 		echo "--- child thread end ---\n";
 	}
 };
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 $thread->join();
 echo "OK\n";
 ?>

--- a/tests/functions.phpt
+++ b/tests/functions.phpt
@@ -15,7 +15,7 @@ class TestThread extends \pmmp\thread\Thread {
 }
 
 $thread = new TestThread();
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 ?>
 --EXPECT--
 TestFunction

--- a/tests/get-current-thread.phpt
+++ b/tests/get-current-thread.phpt
@@ -11,7 +11,7 @@ $c = new class extends \pmmp\thread\Thread{
 		var_dump(\pmmp\thread\Thread::getCurrentThread());
 	}
 };
-$c->start();
+$c->start(\pmmp\thread\Thread::INHERIT_ALL);
 $c->join();
 
 var_dump(\pmmp\thread\Thread::getCurrentThread());

--- a/tests/getopt.phpt
+++ b/tests/getopt.phpt
@@ -14,7 +14,7 @@ $t = new class extends \pmmp\thread\Thread{
 		var_dump(getopt("a:", array("arg:")));
 	}
 };
-$t->start() && $t->join();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL) && $t->join();
 ?>
 --EXPECT--
 array(2) {

--- a/tests/global-constants.phpt
+++ b/tests/global-constants.phpt
@@ -26,7 +26,7 @@ class TestThread extends \pmmp\thread\Thread {
 }
 
 $thread = new TestThread();
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 ?>
 --EXPECT--
 string:string(8) "mystring"

--- a/tests/gone.phpt
+++ b/tests/gone.phpt
@@ -35,7 +35,7 @@ $array = new \pmmp\thread\ThreadSafeArray();
 $array["sub"] = new \pmmp\thread\ThreadSafeArray();
 
 $t = new T($array);
-$t->start();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL);
 $t->synchronized(function() use ($t) : void{
 	while(!$t->dereferenced1){
 		$t->wait();

--- a/tests/graceful-fatalities.phpt
+++ b/tests/graceful-fatalities.phpt
@@ -11,7 +11,7 @@ class TestThread extends \pmmp\thread\Thread {
 	}
 }
 $test = new TestThread();
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->join();
 var_dump($test->isTerminated());
 ?>

--- a/tests/included-files.phpt
+++ b/tests/included-files.phpt
@@ -16,7 +16,7 @@ class TestThread extends \pmmp\thread\Thread {
 	}
 }
 $test = new TestThread();
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 ?>
 --EXPECT--
 OK

--- a/tests/inherited-anon-class-outside-context.phpt
+++ b/tests/inherited-anon-class-outside-context.phpt
@@ -35,7 +35,7 @@ class Test extends \pmmp\thread\Thread {
 			public static function staticMethod() {}
 		};
 		var_dump($this->anonymous);
-		$this->anonymous->start();
+		$this->anonymous->start(\pmmp\thread\Thread::INHERIT_ALL);
 		$this->anonymous->join();
 		$this->synchronized(function() : void{
 			$this->notify();
@@ -48,7 +48,7 @@ class Test extends \pmmp\thread\Thread {
 	}
 }
 $test = new Test();
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->synchronized(function() use ($test) : void{
 	while(!isset($test->anonymous, $test->anonymous->ready)) {
 		$test->wait();

--- a/tests/inherited-anon-class.phpt
+++ b/tests/inherited-anon-class.phpt
@@ -10,7 +10,7 @@ $task = new class extends \pmmp\thread\Thread {
 		var_dump($this->prop);
     }
 };
-$task->start() && $task->join();
+$task->start(\pmmp\thread\Thread::INHERIT_ALL) && $task->join();
 --EXPECTF--
 object(%s@anonymous)#2 (0) {
 }

--- a/tests/ini.phpt
+++ b/tests/ini.phpt
@@ -11,7 +11,7 @@ class Test extends \pmmp\thread\Thread {
 	}
 }
 $test = new Test();
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 ?>
 --EXPECT--
 Test::run: :/var/lib/other

--- a/tests/interface.phpt
+++ b/tests/interface.phpt
@@ -22,7 +22,7 @@ class TestThread extends \pmmp\thread\Thread implements INamedThread {
 
 $thread = new TestThread();
 $thread->setName("InterfaceTest");
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 ?>
 --EXPECT--
 InterfaceTest

--- a/tests/interfaces.phpt
+++ b/tests/interfaces.phpt
@@ -29,7 +29,7 @@ class TEST extends \pmmp\thread\Thread {
 }
 
 $test = new TEST();
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 ?>
 --EXPECT--
 bool(true)

--- a/tests/intersection-plus-union-types.phpt
+++ b/tests/intersection-plus-union-types.phpt
@@ -57,7 +57,7 @@ $t = new class extends \pmmp\thread\Thread{
 		echo "--- child thread end ---\n";
 	}
 };
-$t->start();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL);
 $t->join();
 
 echo "OK\n";

--- a/tests/intersection-types.phpt
+++ b/tests/intersection-types.phpt
@@ -47,7 +47,7 @@ $t = new class extends \pmmp\thread\Thread{
 		echo "--- child thread end ---\n";
 	}
 };
-$t->start();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL);
 $t->join();
 
 echo "OK\n";

--- a/tests/iterator-funcs.phpt
+++ b/tests/iterator-funcs.phpt
@@ -48,7 +48,7 @@ class MyThread extends \pmmp\thread\Thread {
 $items = new \MyIterator();
 foreach ($items as $item) {}
 $thread = new \MyThread();
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 $thread->join();
 --EXPECT--
 SUCCESS

--- a/tests/iterator-threaded-fields.phpt
+++ b/tests/iterator-threaded-fields.phpt
@@ -26,7 +26,7 @@ $thread = new class($threaded) extends \pmmp\thread\Thread{
 		}
 	}
 };
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 $thread->join();
 
 ?>

--- a/tests/lexical-vars.phpt
+++ b/tests/lexical-vars.phpt
@@ -44,7 +44,7 @@ $std = new stdClass; # won't work
 $thread = new TestThread(function () use ($scalar, $string, $res, $threaded, $closure, $array, $std) {
     var_dump($scalar, $string, $res, $threaded, $closure, $array, $std);
 });
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 --EXPECTF--
 int(1)
 string(5) "thing"

--- a/tests/new-class-after-thread-creation.phpt
+++ b/tests/new-class-after-thread-creation.phpt
@@ -7,7 +7,7 @@ created, where the new class implements at least one interface
 <?php
 
 $worker = new \pmmp\thread\Worker();
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 interface A {}
 class task extends \pmmp\thread\Runnable implements A {

--- a/tests/new-in-attributes.phpt
+++ b/tests/new-in-attributes.phpt
@@ -23,7 +23,7 @@ $w = new class extends \pmmp\thread\Thread{
 		test();
 	}
 };
-$w->start() && $w->join();
+$w->start(\pmmp\thread\Thread::INHERIT_ALL) && $w->join();
 
 test();
 

--- a/tests/new-in-parameter-initializers.phpt
+++ b/tests/new-in-parameter-initializers.phpt
@@ -14,7 +14,7 @@ $t = new class extends \pmmp\thread\Thread{
 		test();
 	}
 };
-$t->start() && $t->join();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL) && $t->join();
 
 test();
 

--- a/tests/norefs.phpt
+++ b/tests/norefs.phpt
@@ -21,7 +21,7 @@ class T extends \pmmp\thread\Thread {
 
 $t = new T();
 var_dump($t);
-$t->start();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL);
 $t->join();
 ?>
 --EXPECTF--

--- a/tests/normal-reads.phpt
+++ b/tests/normal-reads.phpt
@@ -11,7 +11,7 @@ class Test extends \pmmp\thread\Thread {
 }
 
 $thread = new Test();
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 $thread->join();
 foreach($thread as $key => $value)
 	var_dump($value);

--- a/tests/object-comparison.phpt
+++ b/tests/object-comparison.phpt
@@ -29,11 +29,11 @@ $a = new \pmmp\thread\ThreadSafeArray();
 $b = new \pmmp\thread\ThreadSafeArray();
 
 $test = new Test($a, $b);	# bool(false)
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->join();
 
 $test = new Test($a, $a);	# bool(true)
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->join();
 ?>
 --EXPECT--

--- a/tests/oomethods.phpt
+++ b/tests/oomethods.phpt
@@ -14,7 +14,7 @@ class ThreadTest extends \pmmp\thread\Thread {
 	}
 }
 $thread = new ThreadTest();
-if($thread->start()) {
+if($thread->start(\pmmp\thread\Thread::INHERIT_ALL)) {
 	$thread->join();
 	var_dump($thread->objectTest());
 }

--- a/tests/php8-socket-copy-overwrite-basic.phpt
+++ b/tests/php8-socket-copy-overwrite-basic.phpt
@@ -30,7 +30,7 @@ $thread = new class($threaded) extends \pmmp\thread\Thread{
 		echo "child thread: $addr:$port\n";
 	}
 };
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 $thread->synchronized(function() use ($thread) : void{
 	while(!$thread->started) $thread->wait();

--- a/tests/private-class-constant-fetching.phpt
+++ b/tests/private-class-constant-fetching.phpt
@@ -35,7 +35,7 @@ $t = new class extends \pmmp\thread\Thread {
 	}
 };
 
-$t->start() && $t->join();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL) && $t->join();
 --EXPECT--
 int(1)
 array(2) {

--- a/tests/private-property-shadow.phpt
+++ b/tests/private-property-shadow.phpt
@@ -27,7 +27,7 @@ class B extends A{
 
 $t = new \pmmp\thread\Worker();
 
-$t->start();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL);
 $t->stack(new class extends \pmmp\thread\Runnable{
 	public function run() : void{
 		$b = new B;

--- a/tests/readonly-properties.phpt
+++ b/tests/readonly-properties.phpt
@@ -37,7 +37,7 @@ $t = new class extends \pmmp\thread\Thread{
 		test();
 	}
 };
-$t->start() && $t->join();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL) && $t->join();
 
 test();
 ?>

--- a/tests/return-types.phpt
+++ b/tests/return-types.phpt
@@ -14,7 +14,7 @@ $thread = new class extends \pmmp\thread\Thread {
 	}
 };
 
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 $thread->join();
 --EXPECT--
 string(4) "some"

--- a/tests/selective-inheritance.phpt
+++ b/tests/selective-inheritance.phpt
@@ -21,7 +21,7 @@ class TestThread extends \pmmp\thread\Thread {
 }
 
 $thread = new TestThread();
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 $thread->join();
 unset($thread);
 

--- a/tests/shutdown-handler.phpt
+++ b/tests/shutdown-handler.phpt
@@ -13,7 +13,7 @@ class Test extends \pmmp\thread\Thread {
 }
 
 $test = new Test();
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 ?>
 --EXPECTF--
 object(stdClass)#%d (0) {

--- a/tests/single-copy-strings-basic.phpt
+++ b/tests/single-copy-strings-basic.phpt
@@ -31,7 +31,7 @@ $thread = new class extends \pmmp\thread\Thread{
 		});
 	}
 };
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 $thread->synchronized(function() use ($thread) : void{
 	while($thread->buffer->count() === 0){

--- a/tests/stateful-fatalities.phpt
+++ b/tests/stateful-fatalities.phpt
@@ -10,7 +10,7 @@ class TestThread extends \pmmp\thread\Thread {
 	}
 }
 $test = new TestThread();
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->join();
 var_dump($test->isTerminated());
 ?>

--- a/tests/static-inheritance-no-separation.phpt
+++ b/tests/static-inheritance-no-separation.phpt
@@ -27,7 +27,7 @@ function doTest() : void{
 }
 
 $t = new \pmmp\thread\Worker();
-$t->start();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 $t->stack(new B);
 $t->shutdown();

--- a/tests/static-inheritance-unexpected-null.phpt
+++ b/tests/static-inheritance-unexpected-null.phpt
@@ -22,7 +22,7 @@ class thr extends \pmmp\thread\Thread{
 }
 
 $thr = new thr();
-$thr->start();
+$thr->start(\pmmp\thread\Thread::INHERIT_ALL);
 $thr->join();
 --EXPECT--
 string(1) "A"

--- a/tests/static-resolution.phpt
+++ b/tests/static-resolution.phpt
@@ -21,7 +21,7 @@ class testbug extends \pmmp\thread\Thread
 }
 
 $testbug = new testbug;
-$testbug->start();
+$testbug->start(\pmmp\thread\Thread::INHERIT_ALL);
 ?>
 --EXPECT--
 int(123)

--- a/tests/static-scope-vars.phpt
+++ b/tests/static-scope-vars.phpt
@@ -26,7 +26,7 @@ $objThread = new class extends \pmmp\thread\Thread
     }
 };
 
-$objThread->start();
+$objThread->start(\pmmp\thread\Thread::INHERIT_ALL);
 $objThread->join();
 --EXPECT--
 string(5) "value"

--- a/tests/staticmethods.phpt
+++ b/tests/staticmethods.phpt
@@ -14,7 +14,7 @@ class ThreadTest extends \pmmp\thread\Thread {
 	}
 }
 $thread = new ThreadTest();
-if($thread->start())
+if($thread->start(\pmmp\thread\Thread::INHERIT_ALL))
 	if ($thread->join())
 		var_dump($thread->result);
 ?>

--- a/tests/statics-thorn-in-other-side.phpt
+++ b/tests/statics-thorn-in-other-side.phpt
@@ -24,7 +24,7 @@ var_dump(StaticClass::$list, StaticClass::$test, StaticClass::$testObject);
 echo "\n";
 
 $thread = new ThreadClass;
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 echo "AFTER\n";
 var_dump(StaticClass::$list, StaticClass::$test, StaticClass::$testObject);

--- a/tests/statics.phpt
+++ b/tests/statics.phpt
@@ -11,7 +11,7 @@ class TestThread extends \pmmp\thread\Thread {
 }
 
 $thread = new TestThread();
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 ?>
 --EXPECT--
 string(15) "pthreads rocks!"

--- a/tests/superglobals.phpt
+++ b/tests/superglobals.phpt
@@ -17,7 +17,7 @@ class TestThread extends \pmmp\thread\Thread {
 }
 
 $thread = new TestThread();
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 ?>
 --EXPECT--
 bool(true)

--- a/tests/synchronization.phpt
+++ b/tests/synchronization.phpt
@@ -14,7 +14,7 @@ class T extends \pmmp\thread\Thread {
         }
 }
 $t = new T;
-$t->start();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL);
 $t->synchronized(function($thread){
 	if (!$thread->data) {
 		var_dump($thread->wait());

--- a/tests/thorn-in-side.phpt
+++ b/tests/thorn-in-side.phpt
@@ -27,7 +27,7 @@ class clientThread extends \pmmp\thread\Thread {
 
 
 $objClientThread = new clientThread();
-$objClientThread->start();
+$objClientThread->start(\pmmp\thread\Thread::INHERIT_ALL);
 $objClientThread->join();
 echo "OK\n";
 --EXPECTF--

--- a/tests/thread.phpt
+++ b/tests/thread.phpt
@@ -10,7 +10,7 @@ class ThreadTest extends \pmmp\thread\Thread {
 	}
 }
 $thread = new ThreadTest();
-if($thread->start())
+if($thread->start(\pmmp\thread\Thread::INHERIT_ALL))
 	var_dump($thread->join());
 ?>
 --EXPECT--

--- a/tests/threaded-member-overwrite.phpt
+++ b/tests/threaded-member-overwrite.phpt
@@ -20,7 +20,7 @@ $thread = new class($v, $v2) extends \pmmp\thread\Thread{
 		$this->v->a = $this->v2;
 	}
 };
-$thread->start() && $thread->join();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL) && $thread->join();
 var_dump($v->a);
 
 ?>

--- a/tests/threaded-nested.phpt
+++ b/tests/threaded-nested.phpt
@@ -84,10 +84,10 @@ class Test extends \pmmp\thread\Thread {
         $shared['queue'] = $queue;
 
         $thread = new TestNestedWrite($shared);
-        $thread->start();
+        $thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 
         $thread2 = new TestNestedRead($shared);
-        $thread2->start();
+        $thread2->start(\pmmp\thread\Thread::INHERIT_ALL);
 
         $shared->synchronized(function() use ($shared) : void{
             while(!isset($shared['lock3'])){
@@ -105,7 +105,7 @@ class Test extends \pmmp\thread\Thread {
     }
 }
 $thread = new Test();
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 $thread->join();
 ?>
 --EXPECT--

--- a/tests/threaded-outlive-creator-lifetime.phpt
+++ b/tests/threaded-outlive-creator-lifetime.phpt
@@ -32,7 +32,7 @@ $t = new class extends \pmmp\thread\Thread{
 	}
 };
 
-$t->start();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL);
 $chan = $t->synchronized(function() use($t) : \pmmp\thread\ThreadSafeArray{
 	while($t->chan === null){
 		$t->wait();

--- a/tests/trait-alias-bug.phpt
+++ b/tests/trait-alias-bug.phpt
@@ -24,7 +24,7 @@ class My extends \pmmp\thread\Thread{
 }
 
 $a = new My();
-$a->start();
+$a->start(\pmmp\thread\Thread::INHERIT_ALL);
 $a->join();
 --EXPECTF--
 %i

--- a/tests/trait-aliases-reflection.phpt
+++ b/tests/trait-aliases-reflection.phpt
@@ -19,7 +19,7 @@ $t = new class extends \pmmp\thread\Thread {
         var_dump($class->getTraitAliases());
     }
 };
-$t->start() && $t->join();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL) && $t->join();
 --EXPECT--
 array(1) {
   ["sun"]=>

--- a/tests/trait-aliases.phpt
+++ b/tests/trait-aliases.phpt
@@ -19,7 +19,7 @@ class myThread extends \pmmp\thread\Thread {
 }
 
 $t = new myThread();
-$t->start();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL);
 $t->join();
 --EXPECT--
 string(9) "fromTrait"

--- a/tests/typed-properties-8.0.phpt
+++ b/tests/typed-properties-8.0.phpt
@@ -74,7 +74,7 @@ testNonStatics();
 echo "--- main thread end ---\n";
 
 $w = new \pmmp\thread\Worker;
-$w->start();
+$w->start(\pmmp\thread\Thread::INHERIT_ALL);
 $w->stack(new class extends \pmmp\thread\Runnable{
 	public function run() : void{
 		echo "--- worker thread start ---\n";

--- a/tests/uncaught-error-after-thread-start.phpt
+++ b/tests/uncaught-error-after-thread-start.phpt
@@ -22,7 +22,7 @@ $t = new class extends \pmmp\thread\Thread{
 		});
 	}
 };
-$t->start();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL);
 $t->synchronized(function() use ($t) : void{
 	while(!$t->ready){
 		$t->wait();

--- a/tests/unprepared-entry-static-segfault.phpt
+++ b/tests/unprepared-entry-static-segfault.phpt
@@ -25,7 +25,7 @@ class Test extends \pmmp\thread\Thread {
 }
 
 $objTestThread = new Test();
-$objTestThread->start();
+$objTestThread->start(\pmmp\thread\Thread::INHERIT_ALL);
 $objTestThread->join();
 --EXPECT--
 SystemLoaderConfig

--- a/tests/unset-defaults.phpt
+++ b/tests/unset-defaults.phpt
@@ -13,7 +13,7 @@ class TestThread extends \pmmp\thread\Thread {
 }
 
 $thread = new TestThread();
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 ?>
 --EXPECT--
 NULL

--- a/tests/unstack-running.phpt
+++ b/tests/unstack-running.phpt
@@ -5,7 +5,7 @@ Unstacking a task would cause it to be freed from the worker stack, but a curren
 --FILE--
 <?php
 $w = new \pmmp\thread\Worker();
-$w->start();
+$w->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 class Task extends \pmmp\thread\Runnable{
     public function run() : void{

--- a/tests/user-defined-join-no-call-parent.phpt
+++ b/tests/user-defined-join-no-call-parent.phpt
@@ -22,7 +22,7 @@ $c = new class extends \pmmp\thread\Thread{
 		return false; //not calling the parent will cause the thread to only be joined by the dtor
 	}
 };
-$c->start();
+$c->start(\pmmp\thread\Thread::INHERIT_ALL);
 unset($c); //trigger destructor
 echo "OK\n"; //this will never be reached if the dtor doesn't do its job
 --EXPECT--

--- a/tests/user-defined-join.phpt
+++ b/tests/user-defined-join.phpt
@@ -22,7 +22,7 @@ $c = new class extends \pmmp\thread\Thread{
 		return parent::join();
 	}
 };
-$c->start();
+$c->start(\pmmp\thread\Thread::INHERIT_ALL);
 unset($c); //trigger destructor
 echo "OK\n"; //this will never be reached if the dtor doesn't do its job
 --EXPECT--

--- a/tests/wait.phpt
+++ b/tests/wait.phpt
@@ -19,7 +19,7 @@ class ThreadTest extends \pmmp\thread\Thread {
 	}
 }
 $thread = new ThreadTest();
-if($thread->start()) {
+if($thread->start(\pmmp\thread\Thread::INHERIT_ALL)) {
 	$thread->synchronized(function($me){
 	    if (!$me->sent) {
 		    var_dump($me->wait());

--- a/tests/waiting-timeouts.phpt
+++ b/tests/waiting-timeouts.phpt
@@ -23,7 +23,7 @@ class T extends \pmmp\thread\Thread {
 }
 
 $t = new T;
-$t->start();
+$t->start(\pmmp\thread\Thread::INHERIT_ALL);
 $t->synchronized(function($thread){
 	var_dump($thread->wait(100)); # should return false because no notification sent
 								  # but may wake up (and return true) because notification might come from

--- a/tests/worker-stack-free-from-other-thread.phpt
+++ b/tests/worker-stack-free-from-other-thread.phpt
@@ -16,7 +16,7 @@ class TestThread extends \pmmp\thread\Thread{
 
 	public function run() : void{
 		$this->worker = new \pmmp\thread\Worker();
-		$this->worker->start();
+		$this->worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 		$this->synchronized(fn() => $this->notify());
 		$this->synchronized(function() : void{
 			while(!$this->shutdown){
@@ -28,7 +28,7 @@ class TestThread extends \pmmp\thread\Thread{
 };
 
 $thread = new TestThread;
-$thread->start();
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 $thread->synchronized(function() use ($thread) : void{
 	while($thread->worker === null){
 		$thread->wait();

--- a/tests/workers-default-collector.phpt
+++ b/tests/workers-default-collector.phpt
@@ -5,7 +5,7 @@ This test verifies that the default collector works as expected
 --FILE--
 <?php
 $worker = new \pmmp\thread\Worker();
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 $i = 0;
 while ($i<10) {

--- a/tests/workers-no-collect.phpt
+++ b/tests/workers-no-collect.phpt
@@ -15,9 +15,9 @@ class Test extends \pmmp\thread\Thread {
 }
 
 $worker = new \pmmp\thread\Worker();
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test = new Test($worker);
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->join();
 ?>
 --EXPECTF--

--- a/tests/workers-no-join.phpt
+++ b/tests/workers-no-join.phpt
@@ -15,9 +15,9 @@ class Test extends \pmmp\thread\Thread {
 }
 
 $worker = new \pmmp\thread\Worker();
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test = new Test($worker);
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->join();
 ?>
 --EXPECTF--

--- a/tests/workers-no-stack.phpt
+++ b/tests/workers-no-stack.phpt
@@ -21,9 +21,9 @@ class Test extends \pmmp\thread\Thread {
 }
 
 $worker = new \pmmp\thread\Worker();
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test = new Test($worker);
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->join();
 $worker->shutdown();
 ?>

--- a/tests/workers-no-start.phpt
+++ b/tests/workers-no-start.phpt
@@ -10,19 +10,19 @@ class Test extends \pmmp\thread\Thread {
 	}
 	
 	public function run() : void{
-		$this->worker->start();
+		$this->worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 	}
 }
 
 $worker = new \pmmp\thread\Worker();
 $test = new Test($worker);
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->join();
 ?>
 --EXPECTF--
 Fatal error: Uncaught RuntimeException: only the creator of this pmmp\thread\Worker may start it in %s:8
 Stack trace:
-#0 %s(8): pmmp\thread\Thread->start()
+#0 %s(8): pmmp\thread\Thread->start(%d)
 #1 [internal function]: Test->run()
 #2 {main}
   thrown in %s on line 8

--- a/tests/workers-no-submit-after-run-crash.phpt
+++ b/tests/workers-no-submit-after-run-crash.phpt
@@ -10,7 +10,7 @@ $w = new class extends \pmmp\thread\Worker{
 		throw new \Exception();
 	}
 };
-$w->start();
+$w->start(\pmmp\thread\Thread::INHERIT_ALL);
 $w->synchronized(function() use ($w) : void{
 	while(!$w->isTerminated()){
 		$w->wait();

--- a/tests/workers-no-submit-after-shutdown.phpt
+++ b/tests/workers-no-submit-after-shutdown.phpt
@@ -4,7 +4,7 @@ Test that workers don't accept tasks after shutdown
 <?php
 
 $w = new \pmmp\thread\Worker();
-$w->start();
+$w->start(\pmmp\thread\Thread::INHERIT_ALL);
 $w->join();
 
 try{

--- a/tests/workers-no-submit-after-task-crash.phpt
+++ b/tests/workers-no-submit-after-task-crash.phpt
@@ -9,7 +9,7 @@ $w->stack(new class extends \pmmp\thread\Runnable{
 		throw new \Exception();
 	}
 });
-$w->start();
+$w->start(\pmmp\thread\Thread::INHERIT_ALL);
 while($w->collect() > 0){
 	usleep(1);
 }

--- a/tests/workers-no-unstack.phpt
+++ b/tests/workers-no-unstack.phpt
@@ -15,10 +15,10 @@ class Test extends \pmmp\thread\Thread {
 }
 
 $worker = new \pmmp\thread\Worker();
-$worker->start();
+$worker->start(\pmmp\thread\Thread::INHERIT_ALL);
 
 $test = new Test($worker);
-$test->start();
+$test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->join();
 ?>
 --EXPECTF--


### PR DESCRIPTION
Since there's no one-size-fits-all for this, we require the user to specify it.

For single-file scripts, it'll usually be necessary to use INHERIT_ALL, since you'll probably want to use classes, functions and constants in the same file that can't be autoloaded. For production applications, which usually follow a one-class-per-file rule, INHERIT_NONE or INHERIT_INI is preferable, since these have significantly less overhead and use much less memory.

## Unaddressed issues
- There's currently no way to set the start options of a `Pool`'s workers other than setting a custom Worker class which overrides `start()`. This isn't ideal. However, we could also just remove `Pool` anyway, since PM doesn't use it.
- Perhaps a good idea to add an `INHERIT_DEFAULT` option, which inherits the recommended minimal stuff?