### PR TITLE
Added Thread::getSharedGlobals() - ThreadSafeArray automatically available to all threads

### DIFF
--- a/classes/thread.c
+++ b/classes/thread.c
@@ -112,5 +112,5 @@ Thread_method(getSharedGlobals)
 {
 	zend_parse_parameters_none_throw();
 
-	RETURN_OBJ_COPY(PMMPTHREAD_ZG(thread_shared_globals));
+	RETURN_OBJ_COPY(&PMMPTHREAD_ZG(thread_shared_globals)->std);
 } /* }}} */

--- a/classes/thread.c
+++ b/classes/thread.c
@@ -105,3 +105,12 @@ Thread_method(getCreatorId)
 
 	ZVAL_LONG(return_value, (PMMPTHREAD_FETCH_TS_FROM(Z_OBJ_P(getThis())))->creator.id);
 } /* }}} */
+
+/* {{{ proto ThreadSafeArray Thread::getSharedGlobals()
+	Returns a ThreadSafeArray of globals accessible to all threads */
+Thread_method(getSharedGlobals)
+{
+	zend_parse_parameters_none_throw();
+
+	RETURN_OBJ_COPY(PMMPTHREAD_ZG(thread_shared_globals));
+} /* }}} */

--- a/php_pmmpthread.c
+++ b/php_pmmpthread.c
@@ -303,7 +303,16 @@ PHP_RSHUTDOWN_FUNCTION(pmmpthread) {
 	zend_hash_destroy(&PMMPTHREAD_ZG(filenames));
 	zend_hash_destroy(&PMMPTHREAD_ZG(closure_base_op_arrays));
 
-	zend_object_release(&PMMPTHREAD_ZG(thread_shared_globals)->std);
+	pmmpthread_zend_object_t* ts_globals = PMMPTHREAD_ZG(thread_shared_globals);
+	if (PMMPTHREAD_IN_CREATOR(ts_globals)) {
+		//this is the main thread (we created these globals), but we may be in a special opcache preload "request"
+		//clean up globals so they don't break the context that follows
+		if (pmmpthread_globals_lock()) {
+			PMMPTHREAD_G(thread_shared_globals) = NULL;
+			pmmpthread_globals_unlock();
+		}
+	}
+	zend_object_release(&ts_globals->std);
 
 	return SUCCESS;
 }

--- a/php_pmmpthread.c
+++ b/php_pmmpthread.c
@@ -245,7 +245,7 @@ static zend_result pmmpthread_init_thread_shared_globals() {
 		zval globals_array;
 
 		if (PMMPTHREAD_G(thread_shared_globals)) { //this is not the main thread - connect to existing globals
-			if (pmmpthread_object_connect(PMMPTHREAD_G(thread_shared_globals), &globals_array) == FAILURE) {
+			if (pmmpthread_object_connect(PMMPTHREAD_G(thread_shared_globals), &globals_array) == 0) {
 				ZEND_ASSERT(0);
 				result = FAILURE;
 			} else {

--- a/php_pmmpthread.c
+++ b/php_pmmpthread.c
@@ -265,7 +265,6 @@ static zend_result pmmpthread_init_thread_shared_globals() {
 
 		if (result == SUCCESS) {
 			PMMPTHREAD_ZG(thread_shared_globals) = PMMPTHREAD_FETCH_FROM(Z_OBJ(globals_array));
-			Z_ADDREF(globals_array);
 		}
 	}
 

--- a/php_pmmpthread.c
+++ b/php_pmmpthread.c
@@ -302,6 +302,12 @@ PHP_RSHUTDOWN_FUNCTION(pmmpthread) {
 	zend_hash_destroy(&PMMPTHREAD_ZG(filenames));
 	zend_hash_destroy(&PMMPTHREAD_ZG(closure_base_op_arrays));
 
+	pmmpthread_zend_object_t* shared_globals = PMMPTHREAD_ZG(thread_shared_globals);
+	if (shared_globals != NULL) {
+		//pmmpthread_base_free will clean up global refs
+		zend_object_release(&shared_globals->std);
+	}
+
 	return SUCCESS;
 }
 

--- a/php_pmmpthread.c
+++ b/php_pmmpthread.c
@@ -302,17 +302,6 @@ PHP_RSHUTDOWN_FUNCTION(pmmpthread) {
 	zend_hash_destroy(&PMMPTHREAD_ZG(filenames));
 	zend_hash_destroy(&PMMPTHREAD_ZG(closure_base_op_arrays));
 
-	pmmpthread_zend_object_t* ts_globals = PMMPTHREAD_ZG(thread_shared_globals);
-	if (PMMPTHREAD_IN_CREATOR(ts_globals)) {
-		//this is the main thread (we created these globals), but we may be in a special opcache preload "request"
-		//clean up globals so they don't break the context that follows
-		if (pmmpthread_globals_lock()) {
-			PMMPTHREAD_G(thread_shared_globals) = NULL;
-			pmmpthread_globals_unlock();
-		}
-	}
-	zend_object_release(&ts_globals->std);
-
 	return SUCCESS;
 }
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -123,7 +123,6 @@ zend_bool pmmpthread_globals_init(){
 } while(0)
 
 		INIT_STRING(run, ZEND_STRL("run"));
-		INIT_STRING(thread_shared_globals, ZEND_STRL("PMMPTHREAD_SHARED_GLOBALS"));
 		INIT_STRING(session.cache_limiter, ZEND_STRL("cache_limiter"));
 		INIT_STRING(session.use_cookies, ZEND_STRL("use_cookies"));
 #undef INIT_STRING

--- a/src/globals.c
+++ b/src/globals.c
@@ -100,6 +100,7 @@ zend_bool pmmpthread_globals_init(){
 		if (PMMPTHREAD_G(failed)) {
 			PMMPTHREAD_G(init)=0;
 		} else {
+			PMMPTHREAD_G(thread_shared_globals) = NULL; //this will be inited on main thread request start
 			zend_hash_init(
 				&PMMPTHREAD_G(objects), 64, NULL, (dtor_func_t) NULL, 1);
 #if HAVE_PMMPTHREAD_EXT_SOCKETS_SUPPORT
@@ -122,6 +123,7 @@ zend_bool pmmpthread_globals_init(){
 } while(0)
 
 		INIT_STRING(run, ZEND_STRL("run"));
+		INIT_STRING(thread_shared_globals, ZEND_STRL("PMMPTHREAD_SHARED_GLOBALS"));
 		INIT_STRING(session.cache_limiter, ZEND_STRL("cache_limiter"));
 		INIT_STRING(session.use_cookies, ZEND_STRL("use_cookies"));
 #undef INIT_STRING

--- a/src/globals.h
+++ b/src/globals.h
@@ -66,7 +66,6 @@ struct _pmmpthread_globals {
 	*/
 	struct _strings {
 		zend_string *run;
-		zend_string *thread_shared_globals;
 		struct _session {
 			zend_string *cache_limiter;
 			zend_string *use_cookies;

--- a/src/globals.h
+++ b/src/globals.h
@@ -42,6 +42,11 @@ struct _pmmpthread_globals {
 	*/
 	HashTable objects;
 
+	/*
+	* ThreadSafeArray instance for true global variables
+	*/
+	pmmpthread_zend_object_t* thread_shared_globals;
+
 #if HAVE_PMMPTHREAD_EXT_SOCKETS_SUPPORT
 	/*
 	* Sockets which have been shared between threads, and so musn't be closed by the destructor
@@ -61,6 +66,7 @@ struct _pmmpthread_globals {
 	*/
 	struct _strings {
 		zend_string *run;
+		zend_string *thread_shared_globals;
 		struct _session {
 			zend_string *cache_limiter;
 			zend_string *use_cookies;

--- a/src/object.c
+++ b/src/object.c
@@ -364,7 +364,7 @@ void pmmpthread_base_free(zend_object *object) {
 		zend_hash_index_del(&PMMPTHREAD_ZG(resolve), (zend_ulong)base->ts_obj);
 	}
 
-	if (PMMPTHREAD_ZG(thread_shared_globals) == object) {
+	if (PMMPTHREAD_ZG(thread_shared_globals) == base) {
 		//clean up our local connection to the shared globals
 		//opcache preload creates a fake request, so we need to ensure that
 		//globals are cleaned up properly for the real main thread

--- a/src/pmmpthread.h
+++ b/src/pmmpthread.h
@@ -121,6 +121,7 @@ ZEND_BEGIN_MODULE_GLOBALS(pmmpthread)
 	HashTable filenames;
 	HashTable closure_base_op_arrays;
 	pmmpthread_zend_object_t* connecting_object;
+	pmmpthread_zend_object_t* thread_shared_globals;
 #if HAVE_PMMPTHREAD_EXT_SOCKETS_SUPPORT
 	zend_object_handlers *original_socket_object_handlers;
 	zend_object_handlers custom_socket_object_handlers;

--- a/src/routine.c
+++ b/src/routine.c
@@ -234,6 +234,11 @@ zend_bool pmmpthread_join(pmmpthread_zend_object_t* thread) {
 	if (thread->worker_data != NULL) {
 		pmmpthread_worker_sync_collectable_tasks(thread->worker_data);
 	}
+	pmmpthread_zend_object_t* user_globals = PMMPTHREAD_ZG(thread_shared_globals);
+	if (pmmpthread_monitor_lock(&user_globals->ts_obj->monitor)) {
+		pmmpthread_store_full_sync_local_properties(&user_globals->std);
+		pmmpthread_monitor_unlock(&user_globals->ts_obj->monitor);
+	}
 
 	pmmpthread_monitor_add(&thread->ts_obj->monitor, PMMPTHREAD_MONITOR_EXIT);
 

--- a/stubs/Thread.stub.php
+++ b/stubs/Thread.stub.php
@@ -129,6 +129,14 @@ abstract class Thread extends Runnable
      */
     public static function getCurrentThreadId() : int{}
 
+	/**
+	 * Returns a ThreadSafeArray of globals accessible to all threads
+	 * Any modification made will be seen by all threads
+	 *
+	 * @return ThreadSafeArray
+	 */
+	public static function getSharedGlobals() : ThreadSafeArray{}
+
     /**
      * Will return the identity of the referenced Thread
      *

--- a/stubs/Thread_arginfo.h
+++ b/stubs/Thread_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0a3b5a02d5c1fb06895fc206d5193f3a223343ce */
+ * Stub hash: cfdc1d2f0d91e022f0b7547da5581516d9b5221c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_pmmp_thread_Thread_getCreatorId, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -8,6 +8,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_pmmp_thread_Thread_getCurre
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_pmmp_thread_Thread_getCurrentThreadId arginfo_class_pmmp_thread_Thread_getCreatorId
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_pmmp_thread_Thread_getSharedGlobals, 0, 0, pmmp\\thread\\ThreadSafeArray, 0)
+ZEND_END_ARG_INFO()
 
 #define arginfo_class_pmmp_thread_Thread_getThreadId arginfo_class_pmmp_thread_Thread_getCreatorId
 
@@ -26,6 +29,7 @@ ZEND_END_ARG_INFO()
 ZEND_METHOD(pmmp_thread_Thread, getCreatorId);
 ZEND_METHOD(pmmp_thread_Thread, getCurrentThread);
 ZEND_METHOD(pmmp_thread_Thread, getCurrentThreadId);
+ZEND_METHOD(pmmp_thread_Thread, getSharedGlobals);
 ZEND_METHOD(pmmp_thread_Thread, getThreadId);
 ZEND_METHOD(pmmp_thread_Thread, isJoined);
 ZEND_METHOD(pmmp_thread_Thread, isStarted);
@@ -37,6 +41,7 @@ static const zend_function_entry class_pmmp_thread_Thread_methods[] = {
 	ZEND_ME(pmmp_thread_Thread, getCreatorId, arginfo_class_pmmp_thread_Thread_getCreatorId, ZEND_ACC_PUBLIC)
 	ZEND_ME(pmmp_thread_Thread, getCurrentThread, arginfo_class_pmmp_thread_Thread_getCurrentThread, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(pmmp_thread_Thread, getCurrentThreadId, arginfo_class_pmmp_thread_Thread_getCurrentThreadId, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(pmmp_thread_Thread, getSharedGlobals, arginfo_class_pmmp_thread_Thread_getSharedGlobals, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(pmmp_thread_Thread, getThreadId, arginfo_class_pmmp_thread_Thread_getThreadId, ZEND_ACC_PUBLIC)
 	ZEND_ME(pmmp_thread_Thread, isJoined, arginfo_class_pmmp_thread_Thread_isJoined, ZEND_ACC_PUBLIC)
 	ZEND_ME(pmmp_thread_Thread, isStarted, arginfo_class_pmmp_thread_Thread_isStarted, ZEND_ACC_PUBLIC)

--- a/tests/anon-interceptors.phpt
+++ b/tests/anon-interceptors.phpt
@@ -49,7 +49,7 @@ string(16) "Bar::__construct"
 string(4) "buzz"
 string(11) "hello world"
 string(11) "hello world"
-object(pmmp\thread\ThreadSafe@anonymous)#3 (1) {
+object(pmmp\thread\ThreadSafe@anonymous)#4 (1) {
   ["buzz":"pmmp\thread\ThreadSafe@anonymous":private]=>
   string(11) "hello world"
 }

--- a/tests/cached-full-sync.phpt
+++ b/tests/cached-full-sync.phpt
@@ -23,8 +23,8 @@ $t1->start(\pmmp\thread\Thread::INHERIT_ALL) && $t1->join();
 var_dump($array);
 ?>
 --EXPECT--
-object(pmmp\thread\ThreadSafeArray)#1 (1) {
+object(pmmp\thread\ThreadSafeArray)#2 (1) {
   [0]=>
-  object(pmmp\thread\ThreadSafeArray)#3 (0) {
+  object(pmmp\thread\ThreadSafeArray)#4 (0) {
   }
 }

--- a/tests/child-thread-to-parent-threaded-dereferencing.phpt
+++ b/tests/child-thread-to-parent-threaded-dereferencing.phpt
@@ -24,11 +24,11 @@ $worker->join();
 var_dump($worker);
 ?>
 --EXPECT--
-object(pmmp\thread\Thread@anonymous)#1 (1) {
+object(pmmp\thread\Thread@anonymous)#2 (1) {
   ["array"]=>
-  object(pmmp\thread\ThreadSafeArray)#2 (2) {
+  object(pmmp\thread\ThreadSafeArray)#3 (2) {
     ["sub"]=>
-    object(pmmp\thread\ThreadSafeArray)#3 (0) {
+    object(pmmp\thread\ThreadSafeArray)#4 (0) {
     }
     ["recursive"]=>
     *RECURSION*

--- a/tests/child-to-parent-values-copying.phpt
+++ b/tests/child-to-parent-values-copying.phpt
@@ -25,7 +25,7 @@ $t->start(\pmmp\thread\Thread::INHERIT_ALL) && $t->join();
 var_dump($t);
 ?>
 --EXPECT--
-object(Test)#1 (3) {
+object(Test)#2 (3) {
   ["permanentInternedString"]=>
   string(18) "pmmp\thread\Thread"
   ["requestInternedString"]=>

--- a/tests/child-worker-to-parent-threaded-dereferencing.phpt
+++ b/tests/child-worker-to-parent-threaded-dereferencing.phpt
@@ -32,11 +32,11 @@ while(!$done){
 }
 ?>
 --EXPECT--
-object(pmmp\thread\Runnable@anonymous)#2 (1) {
+object(pmmp\thread\Runnable@anonymous)#3 (1) {
   ["array"]=>
-  object(pmmp\thread\ThreadSafeArray)#4 (2) {
+  object(pmmp\thread\ThreadSafeArray)#5 (2) {
     ["sub"]=>
-    object(pmmp\thread\ThreadSafeArray)#5 (0) {
+    object(pmmp\thread\ThreadSafeArray)#6 (0) {
     }
     ["recursive"]=>
     *RECURSION*

--- a/tests/class-defaults.phpt
+++ b/tests/class-defaults.phpt
@@ -24,7 +24,7 @@ $test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->join();
 ?>
 --EXPECT--
-object(Test)#1 (2) {
+object(Test)#2 (2) {
   ["string":protected]=>
   string(11) "dlrow olleh"
   ["pstring":"Test":private]=>

--- a/tests/closure-ts-this.phpt
+++ b/tests/closure-ts-this.phpt
@@ -30,8 +30,8 @@ $thread->join();
 
 ?>
 --EXPECT--
-object(Closure)#3 (1) {
+object(Closure)#4 (1) {
   ["this"]=>
-  object(A)#2 (0) {
+  object(A)#3 (0) {
   }
 }

--- a/tests/doc-comments.phpt
+++ b/tests/doc-comments.phpt
@@ -42,7 +42,7 @@ var_dump($reflect->getDocComment());
 
 ?>
 --EXPECTF--
-object(ReflectionMethod)#2 (2) {
+object(ReflectionMethod)#3 (2) {
   ["name"]=>
   string(3) "run"
   ["class"]=>
@@ -54,7 +54,7 @@ string(%d) "/**
     * @package package
     * @subpackage subpackage
     */"
-object(ReflectionMethod)#2 (2) {
+object(ReflectionMethod)#3 (2) {
   ["name"]=>
   string(3) "run"
   ["class"]=>

--- a/tests/exception-handler-caught-nested.phpt
+++ b/tests/exception-handler-caught-nested.phpt
@@ -26,7 +26,7 @@ $test->start(\pmmp\thread\Thread::INHERIT_ALL);
 $test->join();
 --EXPECTF--
 string(6) "Caught"
-object(Exception)#3 (7) {
+object(Exception)#4 (7) {
   ["message":protected]=>
   string(0) ""
   ["string":"Exception":private]=>

--- a/tests/get-current-thread.phpt
+++ b/tests/get-current-thread.phpt
@@ -18,8 +18,8 @@ var_dump(\pmmp\thread\Thread::getCurrentThread());
 ?>
 --EXPECT--
 NULL
-object(pmmp\thread\Thread@anonymous)#1 (0) {
+object(pmmp\thread\Thread@anonymous)#2 (0) {
 }
-object(pmmp\thread\Thread@anonymous)#1 (0) {
+object(pmmp\thread\Thread@anonymous)#2 (0) {
 }
 NULL

--- a/tests/inherited-anon-class-outside-context.phpt
+++ b/tests/inherited-anon-class-outside-context.phpt
@@ -64,7 +64,7 @@ $test->synchronized(function() use ($test) : void{
 });
 $test->join();
 --EXPECT--
-object(pmmp\thread\Thread@anonymous)#2 (3) {
+object(pmmp\thread\Thread@anonymous)#3 (3) {
   ["pubProp"]=>
   NULL
   ["protProp":protected]=>
@@ -73,7 +73,7 @@ object(pmmp\thread\Thread@anonymous)#2 (3) {
   NULL
 }
 string(13) "anonymous run"
-object(pmmp\thread\Thread@anonymous)#3 (4) {
+object(pmmp\thread\Thread@anonymous)#4 (4) {
   ["pubProp"]=>
   NULL
   ["protProp":protected]=>

--- a/tests/inherited-anon-class.phpt
+++ b/tests/inherited-anon-class.phpt
@@ -12,5 +12,5 @@ $task = new class extends \pmmp\thread\Thread {
 };
 $task->start(\pmmp\thread\Thread::INHERIT_ALL) && $task->join();
 --EXPECTF--
-object(%s@anonymous)#2 (0) {
+object(%s@anonymous)#3 (0) {
 }

--- a/tests/intersection-plus-union-types.phpt
+++ b/tests/intersection-plus-union-types.phpt
@@ -64,20 +64,20 @@ echo "OK\n";
 ?>
 --EXPECTF--
 --- main thread start ---
-object(AAndB)#1 (0) {
-}
-acceptIntersection(): Argument #1 ($aAndBOrC) must be of type (A&B)|C, JustA given, called in %s on line %d
-acceptIntersection(): Argument #1 ($aAndBOrC) must be of type (A&B)|C, JustB given, called in %s on line %d
-object(C)#2 (0) {
-}
-acceptIntersection(): Argument #1 ($aAndBOrC) must be of type (A&B)|C, D given, called in %s on line %d
---- main thread end ---
---- child thread start ---
 object(AAndB)#2 (0) {
 }
 acceptIntersection(): Argument #1 ($aAndBOrC) must be of type (A&B)|C, JustA given, called in %s on line %d
 acceptIntersection(): Argument #1 ($aAndBOrC) must be of type (A&B)|C, JustB given, called in %s on line %d
 object(C)#3 (0) {
+}
+acceptIntersection(): Argument #1 ($aAndBOrC) must be of type (A&B)|C, D given, called in %s on line %d
+--- main thread end ---
+--- child thread start ---
+object(AAndB)#3 (0) {
+}
+acceptIntersection(): Argument #1 ($aAndBOrC) must be of type (A&B)|C, JustA given, called in %s on line %d
+acceptIntersection(): Argument #1 ($aAndBOrC) must be of type (A&B)|C, JustB given, called in %s on line %d
+object(C)#4 (0) {
 }
 acceptIntersection(): Argument #1 ($aAndBOrC) must be of type (A&B)|C, D given, called in %s on line %d
 --- child thread end ---

--- a/tests/intersection-types.phpt
+++ b/tests/intersection-types.phpt
@@ -54,13 +54,13 @@ echo "OK\n";
 ?>
 --EXPECTF--
 --- main thread start ---
-object(AAndB)#1 (0) {
+object(AAndB)#2 (0) {
 }
 acceptIntersection(): Argument #1 ($aAndB) must be of type A&B, JustA given, called in %s on line %d
 acceptIntersection(): Argument #1 ($aAndB) must be of type A&B, JustB given, called in %s on line %d
 --- main thread end ---
 --- child thread start ---
-object(AAndB)#2 (0) {
+object(AAndB)#3 (0) {
 }
 acceptIntersection(): Argument #1 ($aAndB) must be of type A&B, JustA given, called in %s on line %d
 acceptIntersection(): Argument #1 ($aAndB) must be of type A&B, JustB given, called in %s on line %d

--- a/tests/isset-unset.phpt
+++ b/tests/isset-unset.phpt
@@ -18,7 +18,7 @@ for($i = 0; $i < 10; $i ++) {
 }
 ?>
 --EXPECT--
-object(pmmp\thread\ThreadSafeArray)#1 (10) {
+object(pmmp\thread\ThreadSafeArray)#2 (10) {
   [0]=>
   int(1)
   [1]=>

--- a/tests/iterator-basic.phpt
+++ b/tests/iterator-basic.phpt
@@ -45,5 +45,5 @@ string(6) "value4"
 string(4) "key4"
 string(7) "string4"
 string(8) "threaded"
-object(pmmp\thread\ThreadSafeArray)#2 (0) {
+object(pmmp\thread\ThreadSafeArray)#3 (0) {
 }

--- a/tests/iterator-threaded-fields.phpt
+++ b/tests/iterator-threaded-fields.phpt
@@ -31,11 +31,11 @@ $thread->join();
 
 ?>
 --EXPECTF--
-object(pmmp\thread\ThreadSafeArray)#3 (0) {
+object(pmmp\thread\ThreadSafeArray)#4 (0) {
+}
+object(pmmp\thread\ThreadSafeArray)#5 (0) {
 }
 object(pmmp\thread\ThreadSafeArray)#4 (0) {
 }
-object(pmmp\thread\ThreadSafeArray)#3 (0) {
-}
-object(pmmp\thread\ThreadSafeArray)#4 (0) {
+object(pmmp\thread\ThreadSafeArray)#5 (0) {
 }

--- a/tests/lexical-vars.phpt
+++ b/tests/lexical-vars.phpt
@@ -49,9 +49,9 @@ $thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 int(1)
 string(5) "thing"
 NULL
-object(pmmp\thread\ThreadSafeArray)#2 (0) {
+object(pmmp\thread\ThreadSafeArray)#3 (0) {
 }
-object(Closure)#3 (0) {
+object(Closure)#4 (0) {
 }
 array(5) {
   [0]=>

--- a/tests/merging-cached-properties.phpt
+++ b/tests/merging-cached-properties.phpt
@@ -18,11 +18,11 @@ $t1->merge($t2);
 var_dump($t1["a"], $t2["a"]); //should be the same object
 ?>
 --EXPECT--
-object(pmmp\thread\ThreadSafeArray)#4 (1) {
+object(pmmp\thread\ThreadSafeArray)#5 (1) {
   ["f"]=>
   int(2)
 }
-object(pmmp\thread\ThreadSafeArray)#4 (1) {
+object(pmmp\thread\ThreadSafeArray)#5 (1) {
   ["f"]=>
   int(2)
 }

--- a/tests/merging-members.phpt
+++ b/tests/merging-members.phpt
@@ -26,7 +26,7 @@ $stores[0]->merge($stores[1], false);
 var_dump($stores[0]);
 ?>
 --EXPECT--
-object(pmmp\thread\ThreadSafeArray)#1 (3) {
+object(pmmp\thread\ThreadSafeArray)#2 (3) {
   ["test"]=>
   string(3) "two"
   ["other"]=>
@@ -34,7 +34,7 @@ object(pmmp\thread\ThreadSafeArray)#1 (3) {
   ["next"]=>
   float(0.01)
 }
-object(pmmp\thread\ThreadSafeArray)#1 (3) {
+object(pmmp\thread\ThreadSafeArray)#2 (3) {
   ["test"]=>
   string(3) "one"
   ["other"]=>

--- a/tests/new-in-attributes.phpt
+++ b/tests/new-in-attributes.phpt
@@ -31,17 +31,17 @@ test();
 --EXPECT--
 array(1) {
   [0]=>
-  object(Attr)#3 (1) {
+  object(Attr)#4 (1) {
     ["object"]=>
-    object(stdClass)#5 (0) {
+    object(stdClass)#6 (0) {
     }
   }
 }
 array(1) {
   [0]=>
-  object(Attr)#3 (1) {
+  object(Attr)#4 (1) {
     ["object"]=>
-    object(stdClass)#5 (0) {
+    object(stdClass)#6 (0) {
     }
   }
 }

--- a/tests/new-in-parameter-initializers.phpt
+++ b/tests/new-in-parameter-initializers.phpt
@@ -20,7 +20,7 @@ test();
 
 ?>
 --EXPECT--
-object(stdClass)#2 (0) {
+object(stdClass)#3 (0) {
 }
-object(stdClass)#2 (0) {
+object(stdClass)#3 (0) {
 }

--- a/tests/norefs.phpt
+++ b/tests/norefs.phpt
@@ -32,7 +32,7 @@ object(T)#%d (%d) {
     bool(true)
   }
 }
-object(pmmp\thread\ThreadSafe)#2 (%d) {
+object(pmmp\thread\ThreadSafe)#%d (%d) {
   ["set"]=>
   bool(true)
 }

--- a/tests/null-member-crash.phpt
+++ b/tests/null-member-crash.phpt
@@ -20,11 +20,11 @@ $test2 = new Test2();
 var_dump($test2);
 ?>
 --EXPECTF--
-object(Test)#1 (1) {
+object(Test)#2 (1) {
   [""]=>
   string(4) "what"
 }
-object(Test2)#2 (1) {
+object(Test2)#3 (1) {
   [""]=>
   string(4) "what"
 }

--- a/tests/shift-pop.phpt
+++ b/tests/shift-pop.phpt
@@ -31,35 +31,35 @@ while (($next = $s->pop())) {
 }
 ?>
 --EXPECT--
-object(pmmp\thread\ThreadSafeArray)#1 (1) {
+object(pmmp\thread\ThreadSafeArray)#2 (1) {
   ["string"]=>
   string(6) "string"
 }
 string(6) "string"
-object(pmmp\thread\ThreadSafeArray)#1 (0) {
+object(pmmp\thread\ThreadSafeArray)#2 (0) {
 }
-object(pmmp\thread\ThreadSafeArray)#1 (1) {
+object(pmmp\thread\ThreadSafeArray)#2 (1) {
   ["string"]=>
   string(6) "string"
 }
 string(6) "string"
-object(pmmp\thread\ThreadSafeArray)#1 (0) {
+object(pmmp\thread\ThreadSafeArray)#2 (0) {
 }
-object(pmmp\thread\ThreadSafeArray)#1 (1) {
+object(pmmp\thread\ThreadSafeArray)#2 (1) {
   [0]=>
   string(4) "help"
 }
 string(4) "help"
-object(pmmp\thread\ThreadSafeArray)#1 (0) {
+object(pmmp\thread\ThreadSafeArray)#2 (0) {
 }
-object(pmmp\thread\ThreadSafeArray)#1 (1) {
+object(pmmp\thread\ThreadSafeArray)#2 (1) {
   [1]=>
   string(4) "next"
 }
 string(4) "next"
-object(pmmp\thread\ThreadSafeArray)#1 (0) {
+object(pmmp\thread\ThreadSafeArray)#2 (0) {
 }
-object(pmmp\thread\ThreadSafeArray)#1 (100) {
+object(pmmp\thread\ThreadSafeArray)#2 (100) {
   [1]=>
   int(1)
   [2]=>

--- a/tests/statics-modify-copied-object-array.phpt
+++ b/tests/statics-modify-copied-object-array.phpt
@@ -32,10 +32,10 @@ echo "script end\n";
 --EXPECTF--
 array(2) {
   [0]=>
-  object(stdClass)#1 (0) {
+  object(stdClass)#2 (0) {
   }
   [1]=>
-  object(stdClass)#2 (0) {
+  object(stdClass)#3 (0) {
   }
 }
 array(0) {

--- a/tests/statics-thorn-in-other-side.phpt
+++ b/tests/statics-thorn-in-other-side.phpt
@@ -33,26 +33,26 @@ echo "\n";
 BEFORE:
 array(2) {
   [0]=>
-  object(StaticClass)#1 (0) {
+  object(StaticClass)#2 (0) {
   }
   [1]=>
-  object(StaticClass)#2 (0) {
+  object(StaticClass)#3 (0) {
   }
 }
 string(11) "randomvalue"
-object(StaticClass)#2 (0) {
+object(StaticClass)#3 (0) {
 }
 
 AFTER
 array(2) {
   [0]=>
-  object(StaticClass)#1 (0) {
+  object(StaticClass)#2 (0) {
   }
   [1]=>
-  object(StaticClass)#2 (0) {
+  object(StaticClass)#3 (0) {
   }
 }
 string(11) "randomvalue"
-object(StaticClass)#2 (0) {
+object(StaticClass)#3 (0) {
 }
 

--- a/tests/threaded-array-properties.phpt
+++ b/tests/threaded-array-properties.phpt
@@ -46,7 +46,7 @@ Warning: Undefined property: pmmp\thread\ThreadSafeArray::$thing in %s on line %
 Attempt to assign property "otherThing" on null
 
 Warning: Undefined property: pmmp\thread\ThreadSafeArray::$thing in %s on line %d
-object(pmmp\thread\ThreadSafeArray)#1 (1) {
+object(pmmp\thread\ThreadSafeArray)#2 (1) {
   ["thing"]=>
   int(2)
 }

--- a/tests/threaded-from-array.phpt
+++ b/tests/threaded-from-array.phpt
@@ -32,15 +32,15 @@ array(2) {
     }
   }
 }
-object(pmmp\thread\ThreadSafeArray)#1 (2) {
+object(pmmp\thread\ThreadSafeArray)#2 (2) {
   ["greeting"]=>
   string(11) "Hello World"
   ["child"]=>
-  object(pmmp\thread\ThreadSafeArray)#2 (2) {
+  object(pmmp\thread\ThreadSafeArray)#3 (2) {
     ["of"]=>
     string(4) "mine"
     ["grandchild"]=>
-    object(pmmp\thread\ThreadSafeArray)#3 (1) {
+    object(pmmp\thread\ThreadSafeArray)#4 (1) {
       ["of"]=>
       string(7) "parents"
     }

--- a/tests/threaded-member-overwrite.phpt
+++ b/tests/threaded-member-overwrite.phpt
@@ -25,5 +25,5 @@ var_dump($v->a);
 
 ?>
 --EXPECT--
-object(pmmp\thread\ThreadSafe)#2 (0) {
+object(pmmp\thread\ThreadSafe)#3 (0) {
 }

--- a/tests/threaded-nested.phpt
+++ b/tests/threaded-nested.phpt
@@ -109,10 +109,10 @@ $thread->start(\pmmp\thread\Thread::INHERIT_ALL);
 $thread->join();
 ?>
 --EXPECT--
-object(pmmp\thread\ThreadSafeArray)#4 (0) {
+object(pmmp\thread\ThreadSafeArray)#5 (0) {
 }
-object(pmmp\thread\ThreadSafeArray)#4 (0) {
+object(pmmp\thread\ThreadSafeArray)#5 (0) {
 }
-object(Node)#4 (0) {
+object(Node)#5 (0) {
 }
 

--- a/tests/true-user-globals-child-before-parent.phpt
+++ b/tests/true-user-globals-child-before-parent.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test that PMMPTHREAD_SHARED_GLOBALS works correctly when accessed on child thread before parent
+--DESCRIPTION--
+Due to chain of ownership, PMMPTHREAD_SHARED_GLOBALS must be initialized by the main thread.
+We cannot JIT it, or a parent thread might try to access it and find out that it doesn't exist.
+--FILE--
+<?php
+
+use pmmp\thread\Thread;
+
+$t = new class extends Thread{
+
+	public function run() : void{
+		//use eval to avoid jitting the auto global on the main thread during compile
+		//we want this to be compiled by the child thread
+		eval('$PMMPTHREAD_SHARED_GLOBALS["test"] = 1;');
+	}
+};
+$t->start(Thread::INHERIT_ALL) && $t->join();
+
+var_dump($PMMPTHREAD_SHARED_GLOBALS);
+
+?>
+--EXPECT--
+object(pmmp\thread\ThreadSafeArray)#1 (1) {
+  ["test"]=>
+  int(1)
+}

--- a/tests/true-user-globals-child-before-parent.phpt
+++ b/tests/true-user-globals-child-before-parent.phpt
@@ -1,7 +1,7 @@
 --TEST--
-Test that PMMPTHREAD_SHARED_GLOBALS works correctly when accessed on child thread before parent
+Test that Thread::getSharedGlobals() works correctly when accessed on child thread before parent
 --DESCRIPTION--
-Due to chain of ownership, PMMPTHREAD_SHARED_GLOBALS must be initialized by the main thread.
+Due to chain of ownership, shared globals must be initialized by the main thread.
 We cannot JIT it, or a parent thread might try to access it and find out that it doesn't exist.
 --FILE--
 <?php
@@ -11,14 +11,12 @@ use pmmp\thread\Thread;
 $t = new class extends Thread{
 
 	public function run() : void{
-		//use eval to avoid jitting the auto global on the main thread during compile
-		//we want this to be compiled by the child thread
-		eval('$PMMPTHREAD_SHARED_GLOBALS["test"] = 1;');
+		Thread::getSharedGlobals()["test"] = 1;
 	}
 };
 $t->start(Thread::INHERIT_ALL) && $t->join();
 
-var_dump($PMMPTHREAD_SHARED_GLOBALS);
+var_dump(Thread::getSharedGlobals());
 
 ?>
 --EXPECT--

--- a/tests/true-user-globals-child-to-parent-dereference.phpt
+++ b/tests/true-user-globals-child-to-parent-dereference.phpt
@@ -1,7 +1,7 @@
 --TEST--
-Test that thread-safe objects in PMMPTHREAD_SHARED_GLOBALS placed by child threads are synced by parent threads during join
+Test that thread-safe objects in Thread::getSharedGlobals() placed by child threads are synced by parent threads during join
 --DESCRIPTION--
-PMMPTHREAD_SHARED_GLOBALS isn't owned by any thread, so chain of ownership of objects is interrupted.
+Thread shared globals aren't owned by any thread, so there is no chain of ownership for object rescue.
 We need to ensure that join() rescues objects in the shared globals which were put there by the child thread.
 --FILE--
 <?php
@@ -11,12 +11,12 @@ use pmmp\thread\ThreadSafeArray;
 
 $t = new class extends Thread{
 	public function run() : void{
-		$PMMPTHREAD_SHARED_GLOBALS["test"] = new ThreadSafeArray();
+		Thread::getSharedGlobals()["test"] = new ThreadSafeArray();
 	}
 };
 $t->start(Thread::INHERIT_ALL) && $t->join();
 
-var_dump($PMMPTHREAD_SHARED_GLOBALS["test"]);
+var_dump(Thread::getSharedGlobals()["test"]);
 ?>
 --EXPECT--
 object(pmmp\thread\ThreadSafeArray)#3 (0) {

--- a/tests/true-user-globals-child-to-parent-dereference.phpt
+++ b/tests/true-user-globals-child-to-parent-dereference.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test that thread-safe objects in PMMPTHREAD_SHARED_GLOBALS placed by child threads are synced by parent threads during join
+--DESCRIPTION--
+PMMPTHREAD_SHARED_GLOBALS isn't owned by any thread, so chain of ownership of objects is interrupted.
+We need to ensure that join() rescues objects in the shared globals which were put there by the child thread.
+--FILE--
+<?php
+
+use pmmp\thread\Thread;
+use pmmp\thread\ThreadSafeArray;
+
+$t = new class extends Thread{
+	public function run() : void{
+		$PMMPTHREAD_SHARED_GLOBALS["test"] = new ThreadSafeArray();
+	}
+};
+$t->start(Thread::INHERIT_ALL) && $t->join();
+
+var_dump($PMMPTHREAD_SHARED_GLOBALS["test"]);
+?>
+--EXPECT--
+object(pmmp\thread\ThreadSafeArray)#3 (0) {
+}

--- a/tests/true-user-globals.phpt
+++ b/tests/true-user-globals.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Basic test of PMMPTHREAD_SHARED_GLOBALS
+--FILE--
+<?php
+
+use pmmp\thread\ThreadSafeArray;
+use pmmp\thread\Thread;
+
+var_dump($PMMPTHREAD_SHARED_GLOBALS);
+$PMMPTHREAD_SHARED_GLOBALS["test"] = new ThreadSafeArray();
+var_dump($PMMPTHREAD_SHARED_GLOBALS);
+
+$thread = new class extends Thread{
+	public function run() : void{
+		var_dump($PMMPTHREAD_SHARED_GLOBALS);
+	}
+};
+$thread->start(Thread::INHERIT_ALL) && $thread->join();
+?>
+--EXPECT--
+object(pmmp\thread\ThreadSafeArray)#1 (0) {
+}
+object(pmmp\thread\ThreadSafeArray)#1 (1) {
+  ["test"]=>
+  object(pmmp\thread\ThreadSafeArray)#2 (0) {
+  }
+}
+object(pmmp\thread\ThreadSafeArray)#1 (1) {
+  ["test"]=>
+  object(pmmp\thread\ThreadSafeArray)#3 (0) {
+  }
+}

--- a/tests/true-user-globals.phpt
+++ b/tests/true-user-globals.phpt
@@ -1,18 +1,18 @@
 --TEST--
-Basic test of PMMPTHREAD_SHARED_GLOBALS
+Basic test of Thread::getSharedGlobals()
 --FILE--
 <?php
 
 use pmmp\thread\ThreadSafeArray;
 use pmmp\thread\Thread;
 
-var_dump($PMMPTHREAD_SHARED_GLOBALS);
-$PMMPTHREAD_SHARED_GLOBALS["test"] = new ThreadSafeArray();
-var_dump($PMMPTHREAD_SHARED_GLOBALS);
+var_dump(Thread::getSharedGlobals());
+Thread::getSharedGlobals()["test"] = new ThreadSafeArray();
+var_dump(Thread::getSharedGlobals());
 
 $thread = new class extends Thread{
 	public function run() : void{
-		var_dump($PMMPTHREAD_SHARED_GLOBALS);
+		var_dump(Thread::getSharedGlobals());
 	}
 };
 $thread->start(Thread::INHERIT_ALL) && $thread->join();

--- a/tests/uninitialized-typed-properties.phpt
+++ b/tests/uninitialized-typed-properties.phpt
@@ -43,7 +43,7 @@ echo "--- Done ---\n";
 ?>
 --EXPECT--
 --- Normal object ---
-object(NTS)#1 (3) {
+object(NTS)#2 (3) {
   ["a"]=>
   int(1)
   ["b"]=>
@@ -51,7 +51,7 @@ object(NTS)#1 (3) {
   ["c"]=>
   NULL
 }
-object(NTS)#1 (2) {
+object(NTS)#2 (2) {
   ["a"]=>
   uninitialized(int)
   ["b"]=>
@@ -71,7 +71,7 @@ bool(false)
 bool(true)
 --- pthreads object ---
 --- properties are currently expected to be in an unstable order ---
-object(TS)#2 (3) {
+object(TS)#3 (3) {
   ["a"]=>
   int(1)
   ["b"]=>
@@ -79,7 +79,7 @@ object(TS)#2 (3) {
   ["c"]=>
   NULL
 }
-object(TS)#2 (2) {
+object(TS)#3 (2) {
   ["b"]=>
   string(5) "hello"
   ["c"]=>

--- a/tests/var-dump-consistency.phpt
+++ b/tests/var-dump-consistency.phpt
@@ -14,17 +14,17 @@ var_dump($t);
 
 ?>
 --EXPECT--
-object(stdClass)#3 (0) {
+object(stdClass)#4 (0) {
 }
-object(pmmp\thread\ThreadSafeArray)#1 (1) {
+object(pmmp\thread\ThreadSafeArray)#2 (1) {
   ["sock"]=>
-  object(Closure)#2 (0) {
+  object(Closure)#3 (0) {
   }
 }
-object(Closure)#2 (0) {
+object(Closure)#3 (0) {
 }
-object(pmmp\thread\ThreadSafeArray)#1 (1) {
+object(pmmp\thread\ThreadSafeArray)#2 (1) {
   ["sock"]=>
-  object(Closure)#2 (0) {
+  object(Closure)#3 (0) {
   }
 }


### PR DESCRIPTION
this is a ThreadSafeArray automatically available to all threads unconditionally.

Implements #80

This is useful for automatically inheriting data between threads without using tmp.

However, I'm not sure if an auto global is necessarily the best solution for this. It's a pain to document.