### PR TITLE
First look at preferring autoload over class copying

### DIFF
--- a/src/prepare.c
+++ b/src/prepare.c
@@ -611,10 +611,15 @@ static zend_class_entry* pthreads_create_entry(const pthreads_ident_t* source, z
 		return NULL;
 	}
 
-	if (candidate->type == ZEND_INTERNAL_CLASS
-		|| candidate->ce_flags & ZEND_ACC_PRELOADED
-	) {
-		return zend_lookup_class(candidate->name);
+	if ((candidate->ce_flags & ZEND_ACC_ANON_CLASS) == 0) {
+		//call autoloaders if available for named classes
+		prepared = zend_lookup_class(candidate->name);
+		if (prepared) {
+			return prepared;
+		} else if (candidate->type == ZEND_INTERNAL_CLASS || candidate->ce_flags & ZEND_ACC_PRELOADED) {
+			zend_error_noreturn(E_CORE_ERROR, "Internal and preloaded classes should always be able to be looked up");
+			return NULL;
+		}
 	}
 
 	lookup = zend_string_tolower(candidate->name);

--- a/src/worker.c
+++ b/src/worker.c
@@ -90,7 +90,9 @@ void pthreads_worker_add_garbage(pthreads_worker_data_t *worker_data, pthreads_q
 		pthreads_queue_push(&worker_data->gc, worker_data->running);
 		worker_data->running = NULL;
 		pthreads_monitor_unlock(worker_data->monitor);
-		pthreads_queue_push_new(done_tasks_cache, work_zval);
+		if (!Z_ISUNDEF_P(work_zval)) { //we may have failed to init the local connection object due to an autoloading error
+			pthreads_queue_push_new(done_tasks_cache, work_zval);
+		}
 	} else {
 		ZEND_ASSERT(0);
 	}


### PR DESCRIPTION
this is currently unfinished, and it will attempt to fire the autoloader for every class when INHERIT_ALL is used, which is not intended.

the aim is to avoid class copying wherever possible, since copying classes is a source of stability issues.

this change also allows sidestepping #73 for named classes.