### PR TITLE
Fixed connecting to an object whose creator no longer references it

### DIFF
--- a/classes/worker.c
+++ b/classes/worker.c
@@ -34,7 +34,7 @@ Worker_method(stack)
 		Z_PARAM_OBJECT_OF_CLASS(work, pmmpthread_ce_runnable)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (!PMMPTHREAD_IN_CREATOR(thread) || thread->original_zobj != NULL) {
+	if (!PMMPTHREAD_IN_CREATOR(thread)) {
 		zend_throw_exception_ex(spl_ce_RuntimeException,
 			0, "only the creator of this %s may call stack",
 			thread->std.ce->name->val);
@@ -62,7 +62,7 @@ Worker_method(unstack)
 
 	zend_parse_parameters_none_throw();
 
-	if (!PMMPTHREAD_IN_CREATOR(thread) || thread->original_zobj != NULL) {
+	if (!PMMPTHREAD_IN_CREATOR(thread)) {
 		zend_throw_exception_ex(spl_ce_RuntimeException,
 			0, "only the creator of this %s may call unstack",
 			thread->std.ce->name->val);
@@ -109,7 +109,7 @@ Worker_method(collect)
 		PMMPTHREAD_WORKER_COLLECTOR_INIT(call, Z_OBJ_P(getThis()));
 	}
 
-	if (!PMMPTHREAD_IN_CREATOR(thread) || thread->original_zobj != NULL) {
+	if (!PMMPTHREAD_IN_CREATOR(thread)) {
 		zend_throw_exception_ex(spl_ce_RuntimeException, 0,
 			"only the creator of this %s may call collect",
 			thread->std.ce->name->val);

--- a/src/routine.c
+++ b/src/routine.c
@@ -162,7 +162,7 @@ zend_bool pmmpthread_start(pmmpthread_zend_object_t* thread, zend_ulong thread_o
 	pmmpthread_routine_arg_t routine;
 	pmmpthread_object_t* ts_obj = thread->ts_obj;
 
-	if (!PMMPTHREAD_IN_CREATOR(thread) || thread->original_zobj != NULL) {
+	if (!PMMPTHREAD_IN_CREATOR(thread)) {
 		zend_throw_exception_ex(spl_ce_RuntimeException,
 			0, "only the creator of this %s may start it",
 			thread->std.ce->name->val);
@@ -200,7 +200,7 @@ zend_bool pmmpthread_start(pmmpthread_zend_object_t* thread, zend_ulong thread_o
 /* {{{ */
 zend_bool pmmpthread_join(pmmpthread_zend_object_t* thread) {
 
-	if (!PMMPTHREAD_IN_CREATOR(thread) || thread->original_zobj != NULL) {
+	if (!PMMPTHREAD_IN_CREATOR(thread)) {
 		zend_throw_exception_ex(spl_ce_RuntimeException,
 			0, "only the creator of this %s may join with it",
 			thread->std.ce->name->val);

--- a/src/store.c
+++ b/src/store.c
@@ -929,9 +929,6 @@ static pmmpthread_storage* pmmpthread_store_create(pmmpthread_ident_t* source, z
 
 			if (instanceof_function(Z_OBJCE_P(unstore), pmmpthread_ce_thread_safe)) {
 				pmmpthread_zend_object_t *threaded = PMMPTHREAD_FETCH_FROM(Z_OBJ_P(unstore));
-				if (threaded->original_zobj != NULL) {
-					threaded = threaded->original_zobj;
-				}
 				MAKE_STORAGE(STORE_TYPE_THREADSAFE_OBJECT, pmmpthread_zend_object_storage_t);
 				storage->object = threaded;
 				break;

--- a/src/thread.h
+++ b/src/thread.h
@@ -46,7 +46,6 @@ typedef struct _pmmpthread_zend_object_t pmmpthread_zend_object_t;
 struct _pmmpthread_zend_object_t {
 	pmmpthread_object_t *ts_obj;
 	pmmpthread_ident_t owner;
-	pmmpthread_zend_object_t *original_zobj; //NULL if this is the original object
 	zend_long local_props_modcount;
 	pmmpthread_worker_data_t *worker_data;
 	zend_object std;

--- a/tests/gone-object-relay.phpt
+++ b/tests/gone-object-relay.phpt
@@ -1,0 +1,88 @@
+--TEST--
+Test that an object can be sent from T1 -> T2, unref'd by T1, and then sent back to T1 without errors
+--DESCRIPTION--
+Due to some old code intended to avoid duplicated connections, we would try to connect directly to the original
+object from the thread that created the object, rather than the thread which gave us the object. This is problematic,
+since the creator thread might no longer reference the object, although it could still (evidently) exist on other threads.
+
+The following test case verifies that an object can still be connected to once its creator doesn't reference it anymore.
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use pmmp\thread\ThreadSafeArray;
+
+$inChannel = new ThreadSafeArray();
+$outChannel = new ThreadSafeArray();
+
+$thread = new class($inChannel, $outChannel) extends \pmmp\thread\Thread{
+	public bool $mainThreadReady = false;
+
+	public function __construct(
+		private ThreadSafeArray $inChannel,
+		private ThreadSafeArray $outChannel
+	){}
+
+	public function run() : void{
+		$object = $this->synchronized(function() : object{
+			while($this->inChannel->count() === 0){
+				$this->wait();
+			}
+			$object = $this->inChannel->shift();
+			$this->notify();
+			return $object;
+		});
+		$object = new ThreadSafeArray();
+		$this->synchronized(function() : void{
+			while(!$this->mainThreadReady){
+				$this->wait();
+			}
+		});
+		$this->synchronized(function() use($object) : void{
+			$this->outChannel[] = $object;
+			$this->notify();
+		});
+	}
+};
+
+$thread->start(\pmmp\thread\Thread::INHERIT_ALL);
+
+var_dump("sending our object");
+$thread->synchronized(function() use($inChannel, $thread) : void{
+	$inChannel[] = new ThreadSafeArray();
+	$thread->notify();
+});
+var_dump("waiting for thread to take object");
+$thread->synchronized(function() use($inChannel, $thread) : void{
+	while($inChannel->count() > 0){
+		$thread->wait();
+	}
+});
+var_dump("destroying cached ref to our object");
+$inChannel["abc"] = new ThreadSafeArray(); //synchronize refs
+
+var_dump("notifying thread to return our object");
+$thread->synchronized(function() use($thread) : void{
+	$thread->mainThreadReady = true;
+	$thread->notify();
+});
+var_dump("waiting for our object to return");
+$thread->synchronized(function() use($outChannel, $thread) : void{
+	while($outChannel->count() === 0){
+		$thread->wait();
+	}
+});
+//our object is now returned to us
+var_dump("recovering our object");
+var_dump($outChannel->shift());
+?>
+--EXPECT--
+string(18) "sending our object"
+string(33) "waiting for thread to take object"
+string(35) "destroying cached ref to our object"
+string(37) "notifying thread to return our object"
+string(32) "waiting for our object to return"
+string(21) "recovering our object"
+object(pmmp\thread\ThreadSafeArray)#6 (0) {
+}

--- a/tests/gone-object-relay.phpt
+++ b/tests/gone-object-relay.phpt
@@ -33,7 +33,6 @@ $thread = new class($inChannel, $outChannel) extends \pmmp\thread\Thread{
 			$this->notify();
 			return $object;
 		});
-		$object = new ThreadSafeArray();
 		$this->synchronized(function() : void{
 			while(!$this->mainThreadReady){
 				$this->wait();


### PR DESCRIPTION
Due to some old code intended to avoid duplicated connections, we would try to connect directly to the original
object from the thread that created the object, rather than the thread which gave us the object. This is problematic,
since the creator thread might no longer reference the object, although it could still (evidently) exist on other threads.

We no longer need to track the original object, since we keep a list of the connection associated with each thread-safe object per thread, so duplicate connections should not happen anymore.

/cc @cooldogedev