### PR TITLE
store: track HashPosition for first and last elements

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -664,9 +664,7 @@ int pmmpthread_store_chunk(zend_object *object, zend_long size, zend_bool preser
 		array_init(chunk);
 		zend_bool stale_local_cache = 0;
 		while((zend_hash_num_elements(Z_ARRVAL_P(chunk)) < size) &&
-			zend_hash_num_elements(&ts_obj->props.hash) > 0) {
-			zstorage = zend_hash_get_current_data_ex(&ts_obj->props.hash, &position);
-			ZEND_ASSERT(zstorage != NULL);
+			(zstorage = zend_hash_get_current_data_ex(&ts_obj->props.hash, &position))) {
 
 			zval key, zv;
 

--- a/src/store.c
+++ b/src/store.c
@@ -548,6 +548,14 @@ int pmmpthread_store_write(zend_object *object, zval *key, zval *write, zend_boo
 		if (result == SUCCESS && was_pmmpthread_object) {
 			_pmmpthread_store_bump_modcount_nolock(threaded);
 		}
+		if (ts_obj->props.first != HT_INVALID_IDX && ts_obj->props.first != 0) {
+			HashPosition start = 0;
+			if (zend_hash_get_current_data_ex(&ts_obj->props.hash, &start) != NULL) {
+				//a table rehash may have occurred, moving all elements to the start of the table
+				//this is usually because the table size was increased to accommodate the new element
+				pmmpthread_store_invalidate_bounds(&ts_obj->props);
+			}
+		}
 		if (key) {
 			//only invalidate position if an arbitrary key was used
 			//if the item was appended, the first element was either unchanged or the position was invalid anyway

--- a/src/store.h
+++ b/src/store.h
@@ -32,6 +32,8 @@
 typedef struct _pmmpthread_store_t {
 	HashTable hash;
 	zend_long modcount;
+	HashPosition first;
+	HashPosition last;
 } pmmpthread_store_t;
 
 void pmmpthread_store_init(pmmpthread_store_t* store);


### PR DESCRIPTION
this produces a huge performance improvement for queues with large internal tables.

an internal table of large size may appear if the array had lots of elements inserted into it and later deleted. this resulted in major performance losses for the reader of the elements, as zend_hash_internal_pointer_reset_ex() had to scan through many IS_UNDEF offsets to find the actual first element.

there are two ways to attack this problem:
1) reallocate the internal table as elements are deleted to reduce the internal table size - this proved to be relatively ineffective 2) track the start and end of the hashtable to avoid repeated scans during every shift() call - this is the approach taken in this commit, and provides major performance benefits

the test case written in #42 now runs to completion substantially faster, without any performance degradation.

more tests are needed to ensure that this works fully as intended, but I chose to take the safe route with invalidating vs updating the offsets, so I think it should be good.